### PR TITLE
New feature: adds experimental IPv6 retry handling to improve external IP detection.

### DIFF
--- a/GetMyIP/Configuration/UserSettings.cs
+++ b/GetMyIP/Configuration/UserSettings.cs
@@ -151,6 +151,24 @@ public partial class UserSettings : ConfigManager<UserSettings>
     private int _retrySeconds = 15;
 
     /// <summary>
+    /// Retry if the external IP address is IPv6 and attempt to obtain an IPv4 address instead.
+    /// </summary>
+    [ObservableProperty]
+    private bool _retryIfIpv6;
+
+    /// <summary>
+    /// Maximum number of retry attempts when IPv6 is returned and IPv4 is preferred.
+    /// </summary>
+    [ObservableProperty]
+    private int _retryIfIpv6Max = 3;
+
+    /// <summary>
+    /// Number of seconds to wait between retry attempts when retrying for IPv4.
+    /// </summary>
+    [ObservableProperty]
+    private int _retryIfIpv6Seconds = 10;
+
+    /// <summary>
     /// Vertical spacing in the data grids.
     /// </summary>
     [ObservableProperty]

--- a/GetMyIP/GetMyIP.csproj
+++ b/GetMyIP/GetMyIP.csproj
@@ -18,8 +18,8 @@
   <!-- Set version and prerelease string (if needed) -->
   <PropertyGroup>
     <VersionValidate>true</VersionValidate>
-    <Version>0.20.0</Version>
-    <VersionPrerelease></VersionPrerelease>
+    <Version>0.21.0</Version>
+    <VersionPrerelease>Beta-1</VersionPrerelease>
   </PropertyGroup>
   <PropertyGroup Condition="$(Configuration) == 'Debug'">
     <VersionInfoGenerateJson>true</VersionInfoGenerateJson>

--- a/GetMyIP/Helpers/IpHelpers.cs
+++ b/GetMyIP/Helpers/IpHelpers.cs
@@ -175,12 +175,55 @@ internal static class IpHelpers
                 {
                     case HttpStatusCode.OK: // 200
                         {
-                            ResetRetryCount();
                             LatestRawExternalJson = await response.Content.ReadAsStringAsync();
                             _log.Debug($"Received status code: {(int)response.StatusCode} - {response.ReasonPhrase} from {baseUri}");
+
+                            if (!CheckJson(url, LatestRawExternalJson))
+                            {
+                                return string.Empty;
+                            }
+
+                            // Check if IPv6 retry feature is enabled and we got an IPv6 address
+                            if (UserSettings.Setting!.RetryIfIpv6)
+                            {
+                                string ipAddress = ExtractIpFromJson(url, LatestRawExternalJson);
+                                if (!string.IsNullOrEmpty(ipAddress) && IsIpv6Address(ipAddress))
+                                {
+                                    _log.Warn($"Received IPv6 address: {ipAddress}. Retrying for IPv4.");
+
+                                    // Use separate retry counter for IPv6 condition
+                                    int ipv6RetryCount = 0;
+                                    int ipv6MaxRetries = Math.Min(Math.Max(UserSettings.Setting.RetryIfIpv6Max, 1), 10);
+                                    int ipv6Delay = Math.Min(Math.Max(UserSettings.Setting.RetryIfIpv6Seconds, 5), 60);
+
+                                    ipv6RetryCount++;
+                                    if (ipv6RetryCount < ipv6MaxRetries)
+                                    {
+                                        string msg = string.Format(CultureInfo.InvariantCulture, 
+                                            "IPv6 address received. Retrying in {0} seconds for IPv4 ({1}/{2})", 
+                                            ipv6Delay, ipv6RetryCount, ipv6MaxRetries);
+                                        _log.Warn(msg);
+                                        MessageHelpers.ShowErrorMessage(msg, MessageHelpers.ErrorSource.externalIP, false);
+                                        await Task.Delay(TimeSpan.FromSeconds(ipv6Delay));
+                                        continue; // Retry the request
+                                    }
+                                    else
+                                    {
+                                        _log.Error($"Max IPv6 retry count ({ipv6MaxRetries}) reached. Returning IPv6 address.");
+                                        string maxMsg = $"Maximum IPv6 retry attempts ({ipv6MaxRetries}) reached. Returning IPv6 address: {ipAddress}";
+                                        MessageHelpers.ShowErrorMessage(maxMsg, MessageHelpers.ErrorSource.externalIP, false);
+                                        ResetRetryCount();
+                                        TrayIconHelpers.ShowProblemIcon = false;
+                                        LastUpdated = DateTime.Now;
+                                        return LatestRawExternalJson;
+                                    }
+                                }
+                            }
+
+                            ResetRetryCount();
                             TrayIconHelpers.ShowProblemIcon = false;
                             LastUpdated = DateTime.Now;
-                            return CheckJson(url, LatestRawExternalJson) ? LatestRawExternalJson : string.Empty;
+                            return LatestRawExternalJson;
                         }
                     case HttpStatusCode.TooManyRequests: // 429
                         _log.Error($"Received status code: {(int)response.StatusCode} - {response.ReasonPhrase} from {baseUri}");
@@ -688,6 +731,79 @@ internal static class IpHelpers
         return true;
     }
     #endregion Check the returned JSON
+
+    #region Extract IP address from JSON
+    /// <summary>
+    /// Extracts the IP address from the returned JSON based on the configured provider.
+    /// </summary>
+    /// <param name="url">The URL from which the JSON was retrieved.</param>
+    /// <param name="json">The JSON string containing the IP information.</param>
+    /// <returns>The extracted IP address, or an empty string if extraction fails.</returns>
+    private static string ExtractIpFromJson(string url, string json)
+    {
+        try
+        {
+            JsonSerializerOptions opts = new()
+            {
+                PropertyNameCaseInsensitive = true
+            };
+
+            switch (UserSettings.Setting!.InfoProvider)
+            {
+                case PublicInfoProvider.IpApiCom:
+                    {
+                        IpApiCom? info = JsonSerializer.Deserialize<IpApiCom>(json, opts);
+                        return info?.IpAddress ?? string.Empty;
+                    }
+                case PublicInfoProvider.SeeIP:
+                    {
+                        SeeIP? info = JsonSerializer.Deserialize<SeeIP>(json, opts);
+                        return info?.IpAddress ?? string.Empty;
+                    }
+                case PublicInfoProvider.FreeIpApi:
+                    {
+                        FreeIpApi? info = JsonSerializer.Deserialize<FreeIpApi>(json, opts);
+                        return info?.IpAddress ?? string.Empty;
+                    }
+                case PublicInfoProvider.IP2Location:
+                    {
+                        IP2Location? info = JsonSerializer.Deserialize<IP2Location>(json, opts);
+                        return info?.IpAddress ?? string.Empty;
+                    }
+                default:
+                    _log.Warn("Unknown provider when attempting to extract IP address.");
+                    return string.Empty;
+            }
+        }
+        catch (Exception ex)
+        {
+            _log.Warn(ex, "Error extracting IP address from JSON during IPv6 check");
+            return string.Empty;
+        }
+    }
+    #endregion Extract IP address from JSON
+
+    #region Check if IP address is IPv6
+    /// <summary>
+    /// Determines if the given IP address is an IPv6 address.
+    /// </summary>
+    /// <param name="ipAddress">The IP address string to check.</param>
+    /// <returns><see langword="true"/> if the address is IPv6, <see langword="false"/> if IPv4 or invalid.</returns>
+    private static bool IsIpv6Address(string ipAddress)
+    {
+        if (string.IsNullOrWhiteSpace(ipAddress))
+        {
+            return false;
+        }
+
+        if (IPAddress.TryParse(ipAddress, out IPAddress? parsedAddress))
+        {
+            return parsedAddress.AddressFamily == System.Net.Sockets.AddressFamily.InterNetworkV6;
+        }
+
+        return false;
+    }
+    #endregion Check if IP address is IPv6
 
     #region Show the last refresh time
     /// <summary>

--- a/GetMyIP/Helpers/IpHelpers.cs
+++ b/GetMyIP/Helpers/IpHelpers.cs
@@ -181,6 +181,9 @@ internal static class IpHelpers
 
                             if (!CheckJson(url, LatestRawExternalJson))
                             {
+                                TrayIconHelpers.ShowProblemIcon = true;
+                                ShowLastRefresh();
+                                ResetIpv6RetryCount();
                                 return string.Empty;
                             }
 

--- a/GetMyIP/Helpers/IpHelpers.cs
+++ b/GetMyIP/Helpers/IpHelpers.cs
@@ -16,6 +16,7 @@ internal static class IpHelpers
     private static FreeIpApi? _infoFreeIpApi;
     private static IP2Location? _infoIp2Location;
     private static int _retryCount;
+    private static int _ipv6RetryCount;
     // Reuse the HttpClient instance across requests.
     private static readonly HttpClient _httpClient = new();
     #endregion Private fields
@@ -184,40 +185,44 @@ internal static class IpHelpers
                             }
 
                             // Check if IPv6 retry feature is enabled and we got an IPv6 address
-                            if (UserSettings.Setting!.RetryIfIpv6)
+                            if (UserSettings.Setting.RetryIfIpv6)
                             {
-                                string ipAddress = ExtractIpFromJson(url, LatestRawExternalJson);
+                                string ipAddress = ExtractIpFromJson(LatestRawExternalJson);
                                 if (!string.IsNullOrEmpty(ipAddress) && IsIpv6Address(ipAddress))
                                 {
-                                    _log.Warn($"Received IPv6 address: {ipAddress}. Retrying for IPv4.");
+                                    int ipv6MaxRetries = Math.Min(Math.Max(UserSettings.Setting.RetryIfIpv6Max, 1), 100);
+                                    int ipv6Delay = Math.Min(Math.Max(UserSettings.Setting.RetryIfIpv6Seconds, 2), 60);
 
-                                    // Use separate retry counter for IPv6 condition
-                                    int ipv6RetryCount = 0;
-                                    int ipv6MaxRetries = Math.Min(Math.Max(UserSettings.Setting.RetryIfIpv6Max, 1), 10);
-                                    int ipv6Delay = Math.Min(Math.Max(UserSettings.Setting.RetryIfIpv6Seconds, 5), 60);
-
-                                    ipv6RetryCount++;
-                                    if (ipv6RetryCount < ipv6MaxRetries)
+                                    _ipv6RetryCount++;
+                                    if (_ipv6RetryCount < ipv6MaxRetries)
                                     {
-                                        string msg = string.Format(CultureInfo.InvariantCulture, 
-                                            "IPv6 address received. Retrying in {0} seconds for IPv4 ({1}/{2})", 
-                                            ipv6Delay, ipv6RetryCount, ipv6MaxRetries);
-                                        _log.Warn(msg);
-                                        MessageHelpers.ShowErrorMessage(msg, MessageHelpers.ErrorSource.externalIP, false);
+                                        _log.Warn($"IPv6 address ({ipAddress}) received while IPv6 retry option enabled. Retrying in {ipv6Delay} seconds ({_ipv6RetryCount}/{ipv6MaxRetries})");
+                                        string msgPart1 = string.Format(CultureInfo.InvariantCulture, MsgTextErrorIPv6Received, ipAddress);
+                                        string msgPart2 = string.Format(CultureInfo.InvariantCulture, MsgTextRetryAttempt, ipv6Delay, _ipv6RetryCount, ipv6MaxRetries);
+                                        string msg = $"{msgPart1}\n{msgPart2}";
+                                        if (_ipv6RetryCount == 1)
+                                        {
+                                            MessageHelpers.ShowErrorMessage(msg, MessageHelpers.ErrorSource.externalIP, true);
+                                        }
+                                        else
+                                        {
+                                            MessageHelpers.ShowErrorMessage(msg, MessageHelpers.ErrorSource.externalIP, false);
+                                        }
                                         await Task.Delay(TimeSpan.FromSeconds(ipv6Delay));
-                                        continue; // Retry the request
+                                        continue; // Retry the request - jump back to the start of the while loop
                                     }
                                     else
                                     {
-                                        _log.Error($"Max IPv6 retry count ({ipv6MaxRetries}) reached. Returning IPv6 address.");
-                                        string maxMsg = $"Maximum IPv6 retry attempts ({ipv6MaxRetries}) reached. Returning IPv6 address: {ipAddress}";
+                                        _log.Error($"Max IPv6 retry count ({_ipv6RetryCount} of {ipv6MaxRetries}) reached.");
+                                        string maxMsgPart1 = string.Format(CultureInfo.InvariantCulture, MsgTextErrorIPv6RetryMaxLine1, ipv6MaxRetries);
+                                        string maxMsgPart2 = GetStringResource("MsgText_Error_IPv6RetryMaxLine2");
+                                        string maxMsg = $"{maxMsgPart1}\n{maxMsgPart2}";
                                         MessageHelpers.ShowErrorMessage(maxMsg, MessageHelpers.ErrorSource.externalIP, false);
-                                        ResetRetryCount();
-                                        TrayIconHelpers.ShowProblemIcon = false;
-                                        LastUpdated = DateTime.Now;
-                                        return LatestRawExternalJson;
+                                        ResetIpv6RetryCount();
+                                        return string.Empty;
                                     }
                                 }
+                                ResetIpv6RetryCount();
                             }
 
                             ResetRetryCount();
@@ -291,7 +296,7 @@ internal static class IpHelpers
     }
     #endregion Get External IP & Geolocation info
 
-    #region Reset the retry counter to zero
+    #region Reset the retry counters to zero
     /// <summary>
     /// Resets the retry count to zero if it has been incremented.
     /// </summary>
@@ -306,7 +311,15 @@ internal static class IpHelpers
             _retryCount = 0;
         }
     }
-    #endregion Reset the retry counter to zero
+
+    private static void ResetIpv6RetryCount()
+    {
+        if (_ipv6RetryCount > 0)
+        {
+            _ipv6RetryCount = 0;
+        }
+    }
+    #endregion Reset the retry counters to zero
 
     #region Delay for retry if needed
     /// <summary>
@@ -736,10 +749,9 @@ internal static class IpHelpers
     /// <summary>
     /// Extracts the IP address from the returned JSON based on the configured provider.
     /// </summary>
-    /// <param name="url">The URL from which the JSON was retrieved.</param>
     /// <param name="json">The JSON string containing the IP information.</param>
     /// <returns>The extracted IP address, or an empty string if extraction fails.</returns>
-    private static string ExtractIpFromJson(string url, string json)
+    private static string ExtractIpFromJson(string json)
     {
         try
         {

--- a/GetMyIP/Helpers/ResourceHelpers.cs
+++ b/GetMyIP/Helpers/ResourceHelpers.cs
@@ -12,6 +12,8 @@ internal static class ResourceHelpers
     internal static CompositeFormat MsgTextUISizeSet { get; } = GetCompositeResource("MsgText_UISizeSet");
     internal static CompositeFormat MsgTextUIThemeSet { get; } = GetCompositeResource("MsgText_UIThemeSet");
     internal static CompositeFormat MsgTextErrorConnecting { get; } = GetCompositeResource("MsgText_Error_Connecting");
+    internal static CompositeFormat MsgTextErrorIPv6Received { get; } = GetCompositeResource("MsgText_Error_IPv6Received");
+    internal static CompositeFormat MsgTextErrorIPv6RetryMaxLine1 { get; } = GetCompositeResource("MsgText_Error_IPv6RetryMaxLine1");
     internal static CompositeFormat MsgTextErrorJsonParsing2 { get; } = GetCompositeResource("MsgText_Error_JsonParsing2");
     internal static CompositeFormat MsgTextFontSizeSet { get; } = GetCompositeResource("MsgText_FontSizeSet");
     internal static CompositeFormat MsgTextMaxRetriesReached { get; } = GetCompositeResource("MsgText_MaxRetriesReached");

--- a/GetMyIP/Languages/Strings.en-US.xaml
+++ b/GetMyIP/Languages/Strings.en-US.xaml
@@ -147,6 +147,9 @@
     <sys:String x:Key="MsgText_Error_ImportingSettings">Error importing settings file.</sys:String>
     <sys:String x:Key="MsgText_Error_InternetNotFound">An Internet connection was not found.</sys:String>
     <sys:String x:Key="MsgText_Error_InvalidURL">The URL used to obtain external IP information is invalid.</sys:String>
+    <sys:String x:Key="MsgText_Error_IPv6Received">IPv6 address ({0}) received while IPv6 retry option is enabled.</sys:String>
+    <sys:String x:Key="MsgText_Error_IPv6RetryMaxLine1">Maximum IPv6 retry attempts ({0}) reached.</sys:String>
+    <sys:String x:Key="MsgText_Error_IPv6RetryMaxLine2">Refresh when ready to try again.</sys:String>
     <sys:String x:Key="MsgText_Error_JsonNull">JSON file is null. Please consider opening an issue and attaching the log file.</sys:String>
     <sys:String x:Key="MsgText_Error_JsonNull2">JSON file is null.</sys:String>
     <sys:String x:Key="MsgText_Error_JsonParsing">Error parsing JSON. {0} Please consider opening an issue and attaching the log file.</sys:String>
@@ -203,6 +206,7 @@
     <sys:String x:Key="NavTitle_Settings">Settings</sys:String>
     <!--  Settings Page Expander Headings  -->
     <sys:String x:Key="SettingsSection_AppSettings">Application Settings</sys:String>
+    <sys:String x:Key="SettingsSection_IPv6Settings">IPv6 Settings (Experimental)</sys:String>
     <sys:String x:Key="SettingsSection_Language">Language Settings</sys:String>
     <sys:String x:Key="SettingsSection_PermLogFile">Permanent Log File Settings</sys:String>
     <sys:String x:Key="SettingsSection_RefreshSettings">Automatic Refresh Settings</sys:String>
@@ -210,6 +214,7 @@
     <sys:String x:Key="SettingsSection_TrayIconSettings">Tray Icon Settings</sys:String>
     <sys:String x:Key="SettingsSection_UISettings">UI Settings</sys:String>
     <sys:String x:Key="SettingsSubHead_AppSettings">Initial page, Provider options, Start options, Include IPV6, and Log options</sys:String>
+    <sys:String x:Key="SettingsSubHead_IPv6Settings">External IPv6 handling</sys:String>
     <sys:String x:Key="SettingsSubHead_Language">Language Settings and Testing</sys:String>
     <sys:String x:Key="SettingsSubHead_PermLogFile">Log File Name, View and Test Logging</sys:String>
     <sys:String x:Key="SettingsSubHead_RefreshSettings">Periodic refresh, Refresh interval, and IP address change notification</sys:String>
@@ -223,6 +228,7 @@
     <sys:String x:Key="SettingsItem_DisplayFont">Display Font</sys:String>
     <sys:String x:Key="SettingsItem_DisplayFontSize">Font Size</sys:String>
     <sys:String x:Key="SettingsItem_EditSettingsWarning">Any changes made to the settings file while the app is running will be overwritten!</sys:String>
+    <sys:String x:Key="SettingsItem_EnableIPv6Retry">Retry if external IPv6 address is returned from the provider</sys:String>
     <sys:String x:Key="SettingsItem_EnableLanguageTesting">Enable language testing</sys:String>
     <sys:String x:Key="SettingsItem_EnableRefresh">Enable periodic refresh</sys:String>
     <sys:String x:Key="SettingsItem_EnableRefreshTooltipLine1">Enabling periodic refresh will cause Get My IP to refresh</sys:String>
@@ -231,6 +237,8 @@
     <sys:String x:Key="SettingsItem_IncludeDebug">Include debug level messages in log file</sys:String>
     <sys:String x:Key="SettingsItem_IncludeIPV6">Include internal IPV6 addresses</sys:String>
     <sys:String x:Key="SettingsItem_InitialPage">Initial page displayed</sys:String>
+    <sys:String x:Key="SettingsItem_IPv6RetryMax">Maximum number of times to try</sys:String>
+    <sys:String x:Key="SettingsItem_IPv6RetrySeconds">Number of seconds between retry attempts</sys:String>
     <sys:String x:Key="SettingsItem_KeepOnTop">Keep Get My IP on top of other windows</sys:String>
     <sys:String x:Key="SettingsItem_KeepWindowOnScreen">Reposition off-screen window</sys:String>
     <sys:String x:Key="SettingsItem_Language">Language</sys:String>

--- a/GetMyIP/Views/SettingsPage.xaml
+++ b/GetMyIP/Views/SettingsPage.xaml
@@ -54,6 +54,8 @@
                 <RowDefinition Height="auto" />
                 <RowDefinition Height="10" />
                 <RowDefinition Height="auto" />
+                <RowDefinition Height="10" />
+                <RowDefinition Height="auto" />
                 <RowDefinition Height="*" />
             </Grid.RowDefinitions>
             <!--#endregion-->
@@ -158,8 +160,8 @@
                                                          Foreground="{DynamicResource MaterialDesign.Brush.Foreground}"
                                                          Kind="InfoOutline" Opacity=".8" />
                                 <TextBlock.ToolTip>
-                                    <TextBlock Text="{DynamicResource SettingsItem_RetryMaxTooltip}" 
-                                               FontSize="14" FontWeight="SemiBold"/>
+                                    <TextBlock FontSize="14" FontWeight="SemiBold"
+                                               Text="{DynamicResource SettingsItem_RetryMaxTooltip}" />
                                 </TextBlock.ToolTip>
                             </TextBlock>
                         </StackPanel>
@@ -183,8 +185,8 @@
                                                          Foreground="{DynamicResource MaterialDesign.Brush.Foreground}"
                                                          Kind="InfoOutline" Opacity=".8" />
                                 <TextBlock.ToolTip>
-                                    <TextBlock Text="{DynamicResource SettingsItem_RetrySecondsTooltip}" 
-                                               FontSize="14" FontWeight="SemiBold"/>
+                                    <TextBlock FontSize="14" FontWeight="SemiBold"
+                                               Text="{DynamicResource SettingsItem_RetrySecondsTooltip}" />
                                 </TextBlock.ToolTip>
                             </TextBlock>
                         </StackPanel>
@@ -208,8 +210,8 @@
                                                          Foreground="{DynamicResource MaterialDesign.Brush.Foreground}"
                                                          Kind="InfoOutline" Opacity=".8" />
                                 <TextBlock.ToolTip>
-                                    <TextBlock Text="{DynamicResource SettingsItem_StartupDelayTooltip}" 
-                                               FontSize="14" FontWeight="SemiBold"/>
+                                    <TextBlock FontSize="14" FontWeight="SemiBold"
+                                               Text="{DynamicResource SettingsItem_StartupDelayTooltip}" />
                                 </TextBlock.ToolTip>
                             </TextBlock>
                         </StackPanel>
@@ -288,7 +290,7 @@
             <!--#endregion-->
 
             <!--#region UI Settings-->
-            <Expander Grid.Row="2"
+            <Expander Grid.Row="4"
                       materialDesign:ExpanderAssist.HorizontalHeaderPadding="20,10,20,10"
                       IsExpanded="{Binding UIExpanderOpen,
                                            Source={x:Static config:TempSettings.Setting}}">
@@ -471,7 +473,7 @@
             <!--#endregion-->
 
             <!--#region Tray icon settings-->
-            <Expander Grid.Row="4"
+            <Expander Grid.Row="6"
                       materialDesign:ExpanderAssist.HorizontalHeaderPadding="20,10,20,10"
                       IsExpanded="{Binding IconExpanderOpen,
                                            Source={x:Static config:TempSettings.Setting}}">
@@ -707,8 +709,81 @@
             </Expander>
             <!--#endregion-->
 
-            <!--#region Refresh settings-->
+            <!--#region IPv6 settings-->
             <Expander Grid.Row="6"
+                      materialDesign:ExpanderAssist.HorizontalHeaderPadding="20,10,20,10"
+                      IsExpanded="{Binding RefreshExpanderOpen,
+                                           Source={x:Static config:TempSettings.Setting}}">
+                <!--#region Expander header-->
+                <Expander.Header>
+                    <ItemsControl Style="{StaticResource ExpanderHeaderGrid}">
+                        <Border Style="{StaticResource ExpanderIndicator}" />
+                        <materialDesign:PackIcon Kind="NetworkOffOutline"
+                                                 Style="{StaticResource ExpanderHeaderIcon}" />
+                        <TextBlock Style="{StaticResource ExpanderHeaderTitle}"
+                                   Text="{DynamicResource SettingsSection_IPv6Settings}" />
+                        <TextBlock Style="{StaticResource ExpanderHeaderSubHead}"
+                                   Text="{DynamicResource SettingsSubHead_IPv6Settings}" />
+                    </ItemsControl>
+                </Expander.Header>
+                <!--#endregion-->
+                <Grid Margin="35,10,0,20">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="45" />
+                        <ColumnDefinition />
+                    </Grid.ColumnDefinitions>
+                    <Grid Grid.Column="1">
+                        <!--#region Row & Column definitions-->
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="38" />
+                            <RowDefinition Height="38" />
+                            <RowDefinition Height="38" />
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="15" />
+                            <ColumnDefinition />
+                        </Grid.ColumnDefinitions>
+                        <!--#endregion-->
+
+                        <CheckBox Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3"
+                                  HorizontalAlignment="Left"
+                                  Width="auto"
+                                  Padding="10,0"
+                                  Content="{DynamicResource SettingsItem_EnableIPv6Retry}"
+                                  IsChecked="{Binding RetryIfIpv6,
+                                                      Source={x:Static config:UserSettings.Setting}}" />
+                        <Label Grid.Row="1" Grid.Column="0"
+                               Width="auto"
+                               VerticalAlignment="Center"
+                               Content="{DynamicResource SettingsItem_IPv6RetryMax}" />
+                        <materialDesign:NumericUpDown Grid.Row="1" Grid.Column="2"
+                                                      Width="Auto" MinWidth="120"
+                                                      Margin="0,4,0,10" Padding="5,0,0,2"
+                                                      HorizontalAlignment="Left"
+                                                      VerticalContentAlignment="Bottom"
+                                                      Maximum="100" Minimum="1"
+                                                      Value="{Binding RetryIfIpv6Max,
+                                                                      Source={x:Static config:UserSettings.Setting}}" />
+                        <Label Grid.Row="2" Grid.Column="0"
+                               Width="auto"
+                               VerticalAlignment="Center"
+                               Content="{DynamicResource SettingsItem_IPv6RetrySeconds}" />
+                        <materialDesign:NumericUpDown Grid.Row="2" Grid.Column="2"
+                                                      Width="Auto" MinWidth="120"
+                                                      Margin="0,4,0,10" Padding="5,0,0,2"
+                                                      HorizontalAlignment="Left"
+                                                      VerticalContentAlignment="Bottom"
+                                                      Maximum="60" Minimum="2"
+                                                      Value="{Binding RetryIfIpv6Seconds,
+                                                                      Source={x:Static config:UserSettings.Setting}}" />
+                    </Grid>
+                </Grid>
+            </Expander>
+            <!--#endregion-->
+
+            <!--#region Refresh settings-->
+            <Expander Grid.Row="8"
                       materialDesign:ExpanderAssist.HorizontalHeaderPadding="20,10,20,10"
                       IsExpanded="{Binding RefreshExpanderOpen,
                                            Source={x:Static config:TempSettings.Setting}}">
@@ -773,7 +848,8 @@
                         </TextBlock>
                     </StackPanel>
 
-                    <StackPanel Grid.Row="1" Grid.Column="1" Margin="39,0"
+                    <StackPanel Grid.Row="1" Grid.Column="1"
+                                Margin="39,0"
                                 Orientation="Horizontal">
                         <TextBlock Width="auto"
                                    VerticalAlignment="Center"
@@ -804,7 +880,7 @@
             <!--#endregion-->
 
             <!--#region Log file settings-->
-            <Expander Grid.Row="8"
+            <Expander Grid.Row="10"
                       materialDesign:ExpanderAssist.HorizontalHeaderPadding="20,10,20,10"
                       IsExpanded="{Binding LogExpanderOpen,
                                            Source={x:Static config:TempSettings.Setting}}">
@@ -896,7 +972,7 @@
             <!--#endregion-->
 
             <!--#region Language settings-->
-            <Expander Grid.Row="10"
+            <Expander Grid.Row="12"
                       materialDesign:ExpanderAssist.HorizontalHeaderPadding="20,10,20,10"
                       IsExpanded="{Binding LangExpanderOpen,
                                            Source={x:Static config:TempSettings.Setting}}">
@@ -1020,7 +1096,7 @@
                                                          Kind="InfoOutline" />
                             </TextBlock>
                             <StackPanel.ToolTip>
-                                <TextBlock LineHeight="18" FontWeight="SemiBold">
+                                <TextBlock FontWeight="SemiBold" LineHeight="18">
                                     <Run Text="{DynamicResource SettingsItem_TranslationToolTipLine1}" />
                                     <LineBreak />
                                     <Run Text="{DynamicResource SettingsItem_TranslationToolTipLine2}" />
@@ -1069,7 +1145,7 @@
             <!--#endregion-->
 
             <!--#region Settings backup-->
-            <Expander Grid.Row="12"
+            <Expander Grid.Row="14"
                       materialDesign:ExpanderAssist.HorizontalHeaderPadding="20,10,20,10"
                       IsExpanded="{Binding BackupExpanderOpen,
                                            Source={x:Static config:TempSettings.Setting}}">


### PR DESCRIPTION
#### PR Summary
Introduces settings and logic to retry for an IPv4 address when an external IPv6 address is returned, with user-configurable limits and delays.
- UserSettings.cs: Added RetryIfIpv6, RetryIfIpv6Max, and RetryIfIpv6Seconds properties.
- IpHelpers.cs: Implemented IPv6 detection and retry logic, including IP extraction and retry counters.
- SettingsPage.xaml: Added new "IPv6 Settings (Experimental)" section and updated layout.
- ResourceHelpers.cs and Strings.en-US.xaml: Added resource strings for new IPv6-related messages and UI labels.
- GetMyIP.csproj: Updated version to 0.21.0 Beta-1.
