### PR TITLE
Add System light/dark theme selection and Pale Graphite theme

### DIFF
--- a/GetMyIP/App.xaml
+++ b/GetMyIP/App.xaml
@@ -12,6 +12,7 @@
                                              ColorAdjustment="{materialDesign:ColorAdjustment}"
                                              PrimaryColor="Blue" SecondaryColor="DeepOrange" />
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesign3.Defaults.xaml" />
+                <ResourceDictionary Source="Styles/ComboBoxStyle.xaml" />
                 <ResourceDictionary Source="Styles/DataGridStyles.xaml" />
                 <ResourceDictionary Source="Styles/ButtonStyles.xaml" />
                 <ResourceDictionary Source="Styles/ExpanderStyles.xaml" />

--- a/GetMyIP/Configuration/UserSettings.cs
+++ b/GetMyIP/Configuration/UserSettings.cs
@@ -308,6 +308,18 @@ public partial class UserSettings : ConfigManager<UserSettings>
     private bool _startWithWindows;
 
     /// <summary>
+    /// Theme to use for light mode when ThemeType.System is selected.
+    /// </summary>
+    [ObservableProperty]
+    private ThemeType _systemLightTheme = ThemeType.Light;
+
+    /// <summary>
+    /// Theme to use for dark mode when ThemeType.System is selected.
+    /// </summary>
+    [ObservableProperty]
+    private ThemeType _systemDarkTheme = ThemeType.Darker;
+
+    /// <summary>
     /// Text for custom tooltip.
     /// </summary>
     [ObservableProperty]

--- a/GetMyIP/Converters/EnumToVisibilityConverter.cs
+++ b/GetMyIP/Converters/EnumToVisibilityConverter.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Tim Kennedy. All Rights Reserved. Licensed under the MIT License.
+
+namespace GetMyIP.Converters;
+
+/// <summary>
+/// Converts an enum value to Visibility based on whether it matches the parameter.
+/// Returns Visible if the value equals the parameter, otherwise Collapsed.
+/// </summary>
+public class EnumToVisibilityConverter : IValueConverter
+{
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value == null || parameter == null)
+        {
+            return Visibility.Collapsed;
+        }
+
+        return value.Equals(parameter) ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        return Binding.DoNothing;
+    }
+}

--- a/GetMyIP/Helpers/MainWindowHelpers.cs
+++ b/GetMyIP/Helpers/MainWindowHelpers.cs
@@ -341,28 +341,37 @@ internal static class MainWindowHelpers
 
         if (mode == ThemeType.System)
         {
-            mode = GetSystemTheme().Equals("light", StringComparison.OrdinalIgnoreCase) ? ThemeType.Light : ThemeType.Darker;
+            mode = GetSystemTheme().Equals("light", StringComparison.OrdinalIgnoreCase)
+                ? UserSettings.Setting!.SystemLightTheme
+                : UserSettings.Setting!.SystemDarkTheme;
         }
 
         switch (mode)
         {
-            case ThemeType.Light:
+            case ThemeType.Light: // Light
                 theme.SetBaseTheme(BaseTheme.Light);
                 theme.Background = Colors.WhiteSmoke;
                 break;
-            case ThemeType.Dark:
+            case ThemeType.LightGray: // Pale Graphite
+                theme.SetBaseTheme(BaseTheme.Light);
+                theme.Background = (Color)ColorConverter.ConvertFromString("#FFD3D3D3");
+                theme.Foreground = (Color)ColorConverter.ConvertFromString("#EE111111");
+                theme.Cards.Background = (Color)ColorConverter.ConvertFromString("#FFE0E0E0");
+                theme.DataGrids.Selected = (Color)ColorConverter.ConvertFromString("#FFC0C0C0");
+                theme.Separators.Background = (Color)ColorConverter.ConvertFromString("#FFA9A9A9");
+                break;
+            case ThemeType.Dark: // Material Design Dark
                 theme.SetBaseTheme(BaseTheme.Dark);
                 theme.DataGrids.RowHoverBackground = (Color)ColorConverter.ConvertFromString("#FF303030");
                 break;
-            case ThemeType.Darker:
-                // Set card and paper background colors a bit darker
+            case ThemeType.Darker: // Darker
                 theme.SetBaseTheme(BaseTheme.Dark);
                 theme.Cards.Background = (Color)ColorConverter.ConvertFromString("#FF141414");
                 theme.Background = (Color)ColorConverter.ConvertFromString("#FF202020");
                 theme.Foreground = (Color)ColorConverter.ConvertFromString("#E5F0F0F0");
                 theme.DataGrids.Selected = (Color)ColorConverter.ConvertFromString("#FF303030");
                 break;
-            case ThemeType.DarkBlue:
+            case ThemeType.DarkBlue: // Midnight Blue
                 theme.SetBaseTheme(BaseTheme.Dark);
                 theme.Background = (Color)ColorConverter.ConvertFromString("#FF000F25");
                 theme.Cards.Background = (Color)ColorConverter.ConvertFromString("#FF011636");

--- a/GetMyIP/Languages/Strings.en-US.xaml
+++ b/GetMyIP/Languages/Strings.en-US.xaml
@@ -243,6 +243,8 @@
     <sys:String x:Key="SettingsItem_KeepWindowOnScreen">Reposition off-screen window</sys:String>
     <sys:String x:Key="SettingsItem_Language">Language</sys:String>
     <sys:String x:Key="SettingsItem_LastRefresh">Last refresh:  </sys:String>
+    <sys:String x:Key="SettingsItem_LightModeTheme">Light Mode Theme</sys:String>
+    <sys:String x:Key="SettingsItem_DarkModeTheme">Dark Mode Theme</sys:String>
     <sys:String x:Key="SettingsItem_MapProvider">Map provider</sys:String>
     <sys:String x:Key="SettingsItem_MinimizeNotClose">Minimize to tray instead of closing</sys:String>
     <sys:String x:Key="SettingsItem_NotifyOnIpChange">Notify when external IP address changes</sys:String>
@@ -358,6 +360,7 @@
     <sys:String x:Key="SettingsEnum_Theme_DarkBlue">Midnight Blue</sys:String>
     <sys:String x:Key="SettingsEnum_Theme_Darker">Darker</sys:String>
     <sys:String x:Key="SettingsEnum_Theme_Light">Light</sys:String>
+    <sys:String x:Key="SettingsEnum_Theme_LightGray">Pale Graphite</sys:String>
     <sys:String x:Key="SettingsEnum_Theme_System">System</sys:String>
 
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -628,4 +631,10 @@
     <!-- Begin changes on 2026/07/04 @ 01:00 UTC -->
     <!-- U | About_BuildDate - Changed 'Build' to 'Commit' -->
     <!-- End of changes on 2026/07/04 @ 01:00 UTC -->
+
+    <!-- Begin changes on 2026/07/06 @ 21:00 UTC-->
+    <!-- A | SettingsEnum_Theme_LightGray  -->
+    <!-- A | SettingsItem_LightModeTheme  -->
+    <!-- A | SettingsItem_DarkModeTheme  -->
+    <!-- End of changes on 2026/07/06 @ 21:00 UTC-->
 </ResourceDictionary>

--- a/GetMyIP/Languages/Strings.en-US.xaml
+++ b/GetMyIP/Languages/Strings.en-US.xaml
@@ -632,9 +632,9 @@
     <!-- U | About_BuildDate - Changed 'Build' to 'Commit' -->
     <!-- End of changes on 2026/07/04 @ 01:00 UTC -->
 
-    <!-- Begin changes on 2026/07/06 @ 21:00 UTC-->
+    <!-- Begin changes on 2026/07/06 @ 21:00 UTC -->
     <!-- A | SettingsEnum_Theme_LightGray  -->
     <!-- A | SettingsItem_LightModeTheme  -->
     <!-- A | SettingsItem_DarkModeTheme  -->
-    <!-- End of changes on 2026/07/06 @ 21:00 UTC-->
+    <!-- End of changes on 2026/07/06 @ 21:00 UTC -->
 </ResourceDictionary>

--- a/GetMyIP/Models/Enums.cs
+++ b/GetMyIP/Models/Enums.cs
@@ -39,7 +39,9 @@ public enum ThemeType
     [LocalizedDescription("SettingsEnum_Theme_System")]
     System = 3,
     [LocalizedDescription("SettingsEnum_Theme_DarkBlue")]
-    DarkBlue = 4
+    DarkBlue = 4,
+    [LocalizedDescription("SettingsEnum_Theme_LightGray")]
+    LightGray = 5
 }
 #endregion Theme
 

--- a/GetMyIP/Styles/ComboBoxStyle.xaml
+++ b/GetMyIP/Styles/ComboBoxStyle.xaml
@@ -1,0 +1,20 @@
+﻿<!--  Copyright (c) Tim Kennedy. All Rights Reserved. Licensed under the MIT License.  -->
+
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!--#region Style for ComboBoxes on Settings pages-->
+    <Style TargetType="ComboBox"
+           x:Key="SettingsComboBox"
+           BasedOn="{StaticResource MaterialDesignComboBox}">
+        <Setter Property="Padding" Value="3,0,0,3"/>
+        <Setter Property="Height" Value="34" />
+        <Setter Property="Width" Value="Auto"/>
+        <Setter Property="MinWidth" Value="200"/>
+        <Setter Property="HorizontalAlignment" Value="Left"/>
+        <Setter Property="VerticalAlignment" Value="Bottom"/>
+        <Setter Property="Margin" Value="0,3,0,0"/>
+    </Style>
+    <!--#endregion-->
+
+</ResourceDictionary>

--- a/GetMyIP/ViewModels/NavigationViewModel.cs
+++ b/GetMyIP/ViewModels/NavigationViewModel.cs
@@ -516,6 +516,9 @@ internal sealed partial class NavigationViewModel : ObservableObject
                     switch (UserSettings.Setting!.UITheme)
                     {
                         case ThemeType.Light:
+                            UserSettings.Setting.UITheme = ThemeType.LightGray;
+                            break;
+                        case ThemeType.LightGray:
                             UserSettings.Setting.UITheme = ThemeType.Dark;
                             break;
                         case ThemeType.Dark:

--- a/GetMyIP/ViewModels/SettingsViewModel.cs
+++ b/GetMyIP/ViewModels/SettingsViewModel.cs
@@ -10,12 +10,34 @@ public partial class SettingsViewModel : ObservableObject
 
     #region Properties
     public static List<FontFamily>? FontList { get; private set; }
+
+    public IEnumerable<ThemeType> ThemeTypes { get; private set; }
+
+    public IEnumerable<ThemeType> SystemThemeTypes { get; private set; }
+
     #endregion Properties
 
     #region Constructor
     public SettingsViewModel()
     {
         FontList ??= [.. Fonts.SystemFontFamilies.OrderBy(x => x.Source)];
+
+        ThemeTypes = [
+    ThemeType.Light,
+            ThemeType.LightGray,
+            ThemeType.Dark,
+            ThemeType.Darker,
+            ThemeType.DarkBlue,
+            ThemeType.System,
+        ];
+
+        SystemThemeTypes = [
+            ThemeType.Light,
+            ThemeType.LightGray,
+            ThemeType.Dark,
+            ThemeType.Darker,
+            ThemeType.DarkBlue,
+        ];
     }
     #endregion Constructor
 

--- a/GetMyIP/Views/SettingsPage.xaml
+++ b/GetMyIP/Views/SettingsPage.xaml
@@ -32,6 +32,8 @@
         <BooleanToVisibilityConverter x:Key="BoolToVisConverter" />
         <converters:BooleanInverter x:Key="BoolInverter" />
         <converters:MultiBoolConverter x:Key="MultiBoolConverter" />
+        <converters:EnumToVisibilityConverter x:Key="EnumToVisibility" />
+
     </UserControl.Resources>
     <!--#endregion-->
 
@@ -319,12 +321,14 @@
                     <Grid Grid.Row="0" Grid.Column="1">
                         <!--#region Row & Column definitions-->
                         <Grid.RowDefinitions>
-                            <RowDefinition Height="38" />
-                            <RowDefinition Height="38" />
-                            <RowDefinition Height="38" />
-                            <RowDefinition Height="38" />
-                            <RowDefinition Height="38" />
-                            <RowDefinition Height="38" />
+                            <RowDefinition Height="auto" />
+                            <RowDefinition Height="auto" />
+                            <RowDefinition Height="auto" />
+                            <RowDefinition Height="auto" />
+                            <RowDefinition Height="auto" />
+                            <RowDefinition Height="auto" />
+                            <RowDefinition Height="auto" />
+                            <RowDefinition Height="auto" />
                         </Grid.RowDefinitions>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto" />
@@ -337,57 +341,80 @@
                                VerticalAlignment="Center"
                                Content="{DynamicResource SettingsItem_Theme}" />
                         <ComboBox Grid.Row="0" Grid.Column="2"
-                                  Width="Auto" MinWidth="180"
-                                  Margin="0,3,0,0" Padding="3,0,0,3"
-                                  HorizontalAlignment="Left"
-                                  ItemsSource="{Binding Source={converters:EnumBindingSource {x:Type models:ThemeType}}}"
+                                  ItemsSource="{Binding ThemeTypes}"
                                   SelectedItem="{Binding UITheme,
                                                          Source={x:Static config:UserSettings.Setting}}"
-                                  Style="{StaticResource MaterialDesignComboBox}" />
-
+                                  Style="{StaticResource SettingsComboBox}" />
+                        
                         <Label Grid.Row="1" Grid.Column="0"
+                                   VerticalAlignment="Center"
+                                   Content="{DynamicResource SettingsItem_LightModeTheme}"
+                                   Visibility="{Binding UITheme,
+                                                        Source={x:Static config:UserSettings.Setting},
+                                                        Converter={StaticResource EnumToVisibility},
+                                                        ConverterParameter={x:Static models:ThemeType.System}}" />
+                        <ComboBox Grid.Row="1" Grid.Column="2"
+                                      ItemsSource="{Binding SystemThemeTypes}"
+                                      SelectedItem="{Binding SystemLightTheme,
+                                                             Source={x:Static config:UserSettings.Setting}}"
+                                      Style="{StaticResource SettingsComboBox}"
+                                      Visibility="{Binding UITheme,
+                                                           Source={x:Static config:UserSettings.Setting},
+                                                           Converter={StaticResource EnumToVisibility},
+                                                           ConverterParameter={x:Static models:ThemeType.System}}" />
+
+                        <Label Grid.Row="2" Grid.Column="0"
+                                   VerticalAlignment="Center"
+                                   Content="{DynamicResource SettingsItem_DarkModeTheme}"
+                                   Visibility="{Binding UITheme,
+                                                        Source={x:Static config:UserSettings.Setting},
+                                                        Converter={StaticResource EnumToVisibility},
+                                                        ConverterParameter={x:Static models:ThemeType.System}}" />
+                        <ComboBox Grid.Row="2" Grid.Column="2"
+                                      ItemsSource="{Binding SystemThemeTypes}"
+                                      SelectedItem="{Binding SystemDarkTheme,
+                                                             Source={x:Static config:UserSettings.Setting}}"
+                                      Style="{StaticResource SettingsComboBox}"
+                                      Visibility="{Binding UITheme,
+                                                           Source={x:Static config:UserSettings.Setting},
+                                                           Converter={StaticResource EnumToVisibility},
+                                                           ConverterParameter={x:Static models:ThemeType.System}}" />
+
+                        <Label Grid.Row="3" Grid.Column="0"
                                VerticalAlignment="Center"
                                Content="{DynamicResource SettingsItem_UISize}" />
-                        <ComboBox Grid.Row="1" Grid.Column="2"
-                                  Width="Auto" MinWidth="180"
-                                  Margin="0,3,0,0" Padding="3,0,0,3"
-                                  HorizontalAlignment="Left"
+                        <ComboBox Grid.Row="3" Grid.Column="2"
                                   ItemsSource="{Binding Source={converters:EnumBindingSource {x:Type models:MySize}}}"
                                   SelectedItem="{Binding UISize,
                                                          Source={x:Static config:UserSettings.Setting}}"
-                                  Style="{StaticResource MaterialDesignComboBox}" />
+                                      Style="{StaticResource SettingsComboBox}"/>
 
-                        <Label Grid.Row="2" Grid.Column="0"
+                        <Label Grid.Row="4" Grid.Column="0"
                                VerticalAlignment="Center"
                                Content="{DynamicResource SettingsItem_AccentColor}" />
-                        <ComboBox Grid.Row="2" Grid.Column="2"
-                                  Width="Auto" MinWidth="180"
-                                  Margin="0,3,0,0" Padding="3,0,0,3"
-                                  HorizontalAlignment="Left"
+                        <ComboBox Grid.Row="4" Grid.Column="2"
                                   ItemsSource="{Binding Source={converters:EnumBindingSource {x:Type models:AccentColor}}}"
                                   MaxDropDownHeight="300"
                                   SelectedItem="{Binding PrimaryColor,
                                                          Source={x:Static config:UserSettings.Setting}}"
-                                  Style="{StaticResource MaterialDesignComboBox}" />
+                                  Style="{StaticResource SettingsComboBox}" />
 
-                        <Label Grid.Row="3" Grid.Column="0"
+                        <Label Grid.Row="5" Grid.Column="0"
                                VerticalAlignment="Center"
                                Content="{DynamicResource SettingsItem_DisplayFont}" />
-                        <ComboBox Grid.Row="3" Grid.Column="2"
-                                  Width="Auto" MinWidth="180"
-                                  Margin="0,3,0,0" Padding="3,0,0,3"
-                                  HorizontalAlignment="Left"
+                        <ComboBox Grid.Row="5" Grid.Column="2"
                                   ItemsSource="{Binding FontList}"
                                   SelectedValue="{Binding SelectedFont,
                                                           Source={x:Static config:UserSettings.Setting}}"
                                   SelectedValuePath="Source"
-                                  Style="{StaticResource MaterialDesignComboBox}" />
+                                  Style="{StaticResource SettingsComboBox}" />
 
-                        <Label Grid.Row="4" Grid.Column="0"
+                        <Label Grid.Row="6" Grid.Column="0"
                                VerticalAlignment="Center"
                                Content="{DynamicResource SettingsItem_DisplayFontSize}" />
-                        <materialDesign:NumericUpDown Grid.Row="4" Grid.Column="2"
-                                                      MinWidth="180"
+                        <materialDesign:NumericUpDown Grid.Row="6" Grid.Column="2"
+                                                      MinWidth="200"
+                                                      Height="33"
                                                       Margin="0,4" Padding="3,0,0,0"
                                                       HorizontalAlignment="Left"
                                                       VerticalContentAlignment="Center"
@@ -395,17 +422,14 @@
                                                       Value="{Binding SelectedFontSize,
                                                                       Source={x:Static config:UserSettings.Setting}}" />
 
-                        <Label Grid.Row="5" Grid.Column="0"
+                        <Label Grid.Row="7" Grid.Column="0"
                                VerticalAlignment="Center"
                                Content="{DynamicResource SettingsItem_RowHeight}" />
-                        <ComboBox Grid.Row="5" Grid.Column="2"
-                                  Width="Auto" MinWidth="180"
-                                  Margin="0,3,0,0" Padding="3,0,0,3"
-                                  HorizontalAlignment="Left"
+                        <ComboBox Grid.Row="7" Grid.Column="2"
                                   ItemsSource="{Binding Source={converters:EnumBindingSource {x:Type models:Spacing}}}"
                                   SelectedItem="{Binding RowSpacing,
                                                          Source={x:Static config:UserSettings.Setting}}"
-                                  Style="{StaticResource MaterialDesignComboBox}" />
+                                  Style="{StaticResource SettingsComboBox}" />
                     </Grid>
 
                     <Grid Grid.Row="1" Grid.Column="1">


### PR DESCRIPTION
Add System light/dark theme selection and Pale Graphite theme

Support selecting separate light/dark themes when "System" theme is active. Add SystemLightTheme and SystemDarkTheme to user settings and update theme application logic. Introduce new "LightGray" (Pale Graphite) theme. Refactor Settings UI with new ComboBox style and conditional visibility for system theme options. Update localization and view model for new theme options.