### PR TITLE
Anonymize user paths in logs for privacy

### DIFF
--- a/GetMyIP/Configuration/ConfigHelpers.cs
+++ b/GetMyIP/Configuration/ConfigHelpers.cs
@@ -104,14 +104,14 @@ public static class ConfigHelpers
 
             if (saveFile.ShowDialog() == true)
             {
-                _log.Debug($"Exporting settings file to {PathHelpers.GetCondensedPath(saveFile.FileName,2,2)}.");
+                _log.Debug($"Exporting settings file to {PathHelpers.AnonymizePath(saveFile.FileName)}.");
                 string json = JsonSerializer.Serialize(UserSettings.Setting, _options);
                 File.WriteAllText(saveFile.FileName, json);
             }
         }
         catch (Exception ex)
         {
-            _log.Debug(ex, "Error exporting settings file.");
+            _log.Debug($"Error exporting settings file. {ex.Message}");
             _ = MessageBox.Show($"{GetStringResource("MsgText_Error_ExportingSettings")}\n{ex.Message}",
                     GetStringResource("MsgText_ErrorCaption"),
                     MessageBoxButton.OK,
@@ -138,7 +138,7 @@ public static class ConfigHelpers
 
             if (importFile.ShowDialog() == true)
             {
-                _log.Debug($"Importing settings file from {PathHelpers.GetCondensedPath(importFile.FileName, 2, 2)}.");
+                _log.Debug($"Importing settings file from {PathHelpers.AnonymizePath(importFile.FileName)}.");
                 ConfigManager<UserSettings>.Setting = JsonSerializer.Deserialize<UserSettings>(File.ReadAllText(importFile.FileName))!;
                 SaveSettings();
 
@@ -152,7 +152,7 @@ public static class ConfigHelpers
         }
         catch (Exception ex)
         {
-            _log.Debug(ex, "Error importing settings file.");
+            _log.Debug($"Error importing settings file. {ex.Message}");
             _ = MessageBox.Show($"{GetStringResource("MsgText_Error_ImportingSettings")}\n{ex.Message}",
                     GetStringResource("MsgText_ErrorCaption"),
                     MessageBoxButton.OK,

--- a/GetMyIP/Helpers/MainWindowHelpers.cs
+++ b/GetMyIP/Helpers/MainWindowHelpers.cs
@@ -297,7 +297,7 @@ internal static class MainWindowHelpers
         _log.Info($"{AppInfo.AppName} {AppInfo.AppCopyright}");
         _log.Debug($"{AppInfo.AppName} Commit date: {BuildInfo.CommitDateStringUtc} - {BuildInfo.CommitDateStringLocal}");
         _log.Debug($"{AppInfo.AppName} Commit ID: {BuildInfo.CommitIDString}");
-        _log.Debug($"{AppInfo.AppName} was started from {PathHelpers.GetCondensedPath(AppInfo.AppPath, 2, 2)}");
+        _log.Debug($"{AppInfo.AppName} was started from {PathHelpers.AnonymizePath(AppInfo.AppPath)}");
         _log.Debug($"{AppInfo.AppName} Process ID: {AppInfo.AppProcessID}");
         if (!string.IsNullOrEmpty(BuildInfo.Prerelease))
         {

--- a/GetMyIP/Helpers/PathHelpers.cs
+++ b/GetMyIP/Helpers/PathHelpers.cs
@@ -70,10 +70,23 @@ internal static class PathHelpers
         }
 
         string userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (string.IsNullOrEmpty(userProfile))
+        {
+            return path;
+        }
+
         if (!path.StartsWith(userProfile, StringComparison.OrdinalIgnoreCase))
         {
             return path;
         }
+
+        // Avoid partial prefix matches (e.g., "C:\Users\Bob" vs "C:\Users\Bobby")
+        if (path.Length > userProfile.Length &&
+            path[userProfile.Length] is not (Path.DirectorySeparatorChar or Path.AltDirectorySeparatorChar))
+        {
+            return path;
+        }
+
         return $"%USERPROFILE%{path[userProfile.Length..]}";
     }
 }

--- a/GetMyIP/Helpers/PathHelpers.cs
+++ b/GetMyIP/Helpers/PathHelpers.cs
@@ -51,4 +51,29 @@ internal static class PathHelpers
 
         return sb.ToString().TrimEnd(Path.DirectorySeparatorChar);
     }
+
+    /// <summary>
+    /// If a path to a file includes the user profile name replace it with %USERPROFILE%.
+    /// </summary>
+    /// <remarks>
+    /// Users may not want to have their user names visible in the log file, especially when sending that log with a bug
+    /// report. This method accomplishes that while still keeping the logged path usable.
+    /// </remarks>
+    /// <returns>
+    /// A string representing the path.
+    /// </returns>
+    public static string AnonymizePath(string path)
+    {
+        if (string.IsNullOrEmpty(path))
+        {
+            return string.Empty;
+        }
+
+        string userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (!path.StartsWith(userProfile, StringComparison.OrdinalIgnoreCase))
+        {
+            return path;
+        }
+        return $"%USERPROFILE%{path[userProfile.Length..]}";
+    }
 }

--- a/GetMyIP/Helpers/TextFileViewer.cs
+++ b/GetMyIP/Helpers/TextFileViewer.cs
@@ -14,7 +14,7 @@ internal static class TextFileViewer
         string fname = string.Empty;
         try
         {
-            fname = PathHelpers.GetCondensedPath(textFile, 2, 2);
+            fname = PathHelpers.AnonymizePath(textFile);
 
             using Process p = new();
             p.StartInfo.FileName = textFile;
@@ -52,7 +52,7 @@ internal static class TextFileViewer
                                 GetStringResource("MsgText_Error_Caption"),
                                 MessageBoxButton.OK,
                                 MessageBoxImage.Error);
-            _log.Error(ex, $"Unable to open {fname}");
+            _log.Error($"Unable to open {fname}. {ex.Message} ");
         }
     }
     #endregion Text file viewer

--- a/GetMyIP/ViewModels/NavigationViewModel.cs
+++ b/GetMyIP/ViewModels/NavigationViewModel.cs
@@ -211,7 +211,7 @@ internal sealed partial class NavigationViewModel : ObservableObject
             {
                 StringBuilder sb = ListToStringBuilder();
                 File.WriteAllText(dialog.FileName, sb.ToString());
-                _log.Debug($"IP information written to {PathHelpers.GetCondensedPath(dialog.FileName, 2, 2)}. ({sb.Length} bytes)");
+                _log.Debug($"IP information written to {PathHelpers.AnonymizePath(dialog.FileName)}. ({sb.Length} bytes)");
             }
         }
         catch (Exception ex)


### PR DESCRIPTION
Replaced GetCondensedPath with AnonymizePath in logging to mask user profile directories as %USERPROFILE%. This prevents exposure of user names in log files. Also updated some exception logging to include only the exception message.