### PR TITLE
Replaces the CommandLineParser library with a custom command-line parser

### DIFF
--- a/GetMyIP/GetMyIP.csproj
+++ b/GetMyIP/GetMyIP.csproj
@@ -60,7 +60,6 @@
 
   <!-- Packages -->
   <ItemGroup>
-    <PackageReference Include="CommandLineArgumentsParser" Version="3.0.23" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageReference Include="H.NotifyIcon.Wpf" Version="2.4.1" />
     <PackageReference Include="MaterialDesignThemes" Version="5.3.2" />

--- a/GetMyIP/GlobalUsings.cs
+++ b/GetMyIP/GlobalUsings.cs
@@ -27,9 +27,6 @@ global using System.Windows.Input;
 global using System.Windows.Markup;
 global using System.Windows.Media;
 
-global using CommandLineParser.Arguments;
-global using CommandLineParser.Exceptions;
-
 global using CommunityToolkit.Mvvm.ComponentModel;
 global using CommunityToolkit.Mvvm.Input;
 

--- a/GetMyIP/Helpers/CommandLineHelpers.cs
+++ b/GetMyIP/Helpers/CommandLineHelpers.cs
@@ -8,39 +8,22 @@ internal static class CommandLineHelpers
     /// <summary>
     /// Holds exception message if there is a parser error.
     /// </summary>
-    public static string? CommandLineParserError {  get; private set; }
+    public static string? CommandLineParserError { get; private set; }
     #endregion Properties
 
     #region Process the command line
     /// <summary>
-    /// Parse any command line options
+    /// Parse any command line options.
     /// </summary>
     /// <returns>CommandLineArgs.Hide if "hide" was found.</returns>
     public static CommandLineArgs ProcessCommandLine()
     {
-        CommandLineParser.CommandLineParser parser = new();
-        SwitchArgument hideArgument = new('h',
-                                                      "hide",
-                                                      "To hide or not to hide, that is the question.",
-                                                      false);
-        parser.Arguments.Add(hideArgument);
-        parser.AcceptSlash = true;
-        parser.IgnoreCase = true;
+        CommandLineParserError = null;
 
-        try
-        {
-            parser.ParseCommandLine(App.Args);
-        }
-        catch (UnknownArgumentException e)
-        {
-            CommandLineParserError = e.Message + e.StackTrace;
-        }
-        catch (Exception e)
-        {
-            CommandLineParserError = e.Message + e.StackTrace;
-        }
+        CommandLineOptions options = CommandLineOptionsParser.Parse(App.Args);
+        CommandLineParserError = options.ErrorMessage;
 
-        return hideArgument.Value ? CommandLineArgs.Hide : CommandLineArgs.None;
+        return options.Hide ? CommandLineArgs.Hide : CommandLineArgs.None;
     }
     #endregion Process the command line
 

--- a/GetMyIP/Helpers/CommandLineHelpers.cs
+++ b/GetMyIP/Helpers/CommandLineHelpers.cs
@@ -6,7 +6,7 @@ internal static class CommandLineHelpers
 {
     #region Properties
     /// <summary>
-    /// Holds exception message if there is a parser error.
+    /// Holds the parser validation message when command-line parsing fails.
     /// </summary>
     public static string? CommandLineParserError { get; private set; }
     #endregion Properties

--- a/GetMyIP/Helpers/CommandLineHelpers.cs
+++ b/GetMyIP/Helpers/CommandLineHelpers.cs
@@ -6,7 +6,7 @@ internal static class CommandLineHelpers
 {
     #region Properties
     /// <summary>
-    /// Holds the parser validation message when command-line parsing fails.
+    /// Holds the parser error message when command-line parsing fails.
     /// </summary>
     public static string? CommandLineParserError { get; private set; }
     #endregion Properties

--- a/GetMyIP/Helpers/CommandLineOptionsParser.cs
+++ b/GetMyIP/Helpers/CommandLineOptionsParser.cs
@@ -10,7 +10,7 @@ internal static class CommandLineOptionsParser
     {
         bool hide = false;
 
-        foreach (string? rawArgument in arguments)
+        foreach (string rawArgument in arguments)
         {
             if (string.IsNullOrWhiteSpace(rawArgument))
             {

--- a/GetMyIP/Helpers/CommandLineOptionsParser.cs
+++ b/GetMyIP/Helpers/CommandLineOptionsParser.cs
@@ -8,6 +8,8 @@ internal static class CommandLineOptionsParser
 {
     internal static CommandLineOptions Parse(IEnumerable<string> arguments)
     {
+        bool hide = false;
+
         foreach (string? rawArgument in arguments)
         {
             if (string.IsNullOrWhiteSpace(rawArgument))
@@ -19,16 +21,17 @@ internal static class CommandLineOptionsParser
 
             if (IsHideArgument(argument))
             {
-                return new CommandLineOptions(true, null);
+                hide = true;
+                continue;
             }
 
             if (IsSwitchArgument(argument))
             {
-                return new CommandLineOptions(false, $"Unknown argument: {rawArgument}");
+                return new CommandLineOptions(hide, $"Unknown argument: {rawArgument}");
             }
         }
 
-        return new CommandLineOptions(false, null);
+        return new CommandLineOptions(hide, null);
     }
 
     private static bool IsHideArgument(string argument)

--- a/GetMyIP/Helpers/CommandLineOptionsParser.cs
+++ b/GetMyIP/Helpers/CommandLineOptionsParser.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Tim Kennedy. All Rights Reserved. Licensed under the MIT License.
+
+namespace GetMyIP.Helpers;
+
+internal sealed record CommandLineOptions(bool Hide, string? ErrorMessage);
+
+internal static class CommandLineOptionsParser
+{
+    internal static CommandLineOptions Parse(IEnumerable<string> arguments)
+    {
+        foreach (string? rawArgument in arguments)
+        {
+            if (string.IsNullOrWhiteSpace(rawArgument))
+            {
+                continue;
+            }
+
+            string argument = rawArgument.Trim();
+
+            if (IsHideArgument(argument))
+            {
+                return new CommandLineOptions(true, null);
+            }
+
+            if (IsSwitchArgument(argument))
+            {
+                return new CommandLineOptions(false, $"Unknown argument: {rawArgument}");
+            }
+        }
+
+        return new CommandLineOptions(false, null);
+    }
+
+    private static bool IsHideArgument(string argument)
+    {
+        string normalized = argument.TrimStart('-', '/');
+
+        return normalized.Equals("h", StringComparison.OrdinalIgnoreCase) ||
+               normalized.Equals("hide", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsSwitchArgument(string argument)
+    {
+        return argument.StartsWith('-') ||
+               argument.StartsWith('/');
+    }
+}

--- a/GetMyIP/Helpers/IpHelpers.cs
+++ b/GetMyIP/Helpers/IpHelpers.cs
@@ -575,6 +575,7 @@ internal static class IpHelpers
                     default:
                         throw new InvalidOperationException("Invalid InfoProvider");
                 }
+                _log.Info($"External IP info logged to {UserSettings.Setting.LogFile}");
             }
             catch (Exception ex)
             {

--- a/GetMyIP/Helpers/IpHelpers.cs
+++ b/GetMyIP/Helpers/IpHelpers.cs
@@ -575,7 +575,11 @@ internal static class IpHelpers
                     default:
                         throw new InvalidOperationException("Invalid InfoProvider");
                 }
-                _log.Info($"External IP info logged to {UserSettings.Setting.LogFile}");
+                string permLogFile = string.IsNullOrEmpty(UserSettings.Setting!.LogFile)
+                    ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Desktop), "GetMyIP.log")
+                    : UserSettings.Setting.LogFile;
+
+                _log.Info($"External IP info logged to {permLogFile}");
             }
             catch (Exception ex)
             {

--- a/GetMyIP/Helpers/IpHelpers.cs
+++ b/GetMyIP/Helpers/IpHelpers.cs
@@ -575,11 +575,7 @@ internal static class IpHelpers
                     default:
                         throw new InvalidOperationException("Invalid InfoProvider");
                 }
-                string permLogFile = string.IsNullOrEmpty(UserSettings.Setting!.LogFile)
-                    ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Desktop), "GetMyIP.log")
-                    : UserSettings.Setting.LogFile;
-
-                _log.Info($"External IP info logged to {permLogFile}");
+                _log.Info($"External IP info logged to {NLogHelpers.GetPermanentLogFilePath()}");
             }
             catch (Exception ex)
             {

--- a/GetMyIP/Helpers/NLogHelpers.cs
+++ b/GetMyIP/Helpers/NLogHelpers.cs
@@ -15,6 +15,13 @@ internal static class NLogHelpers
     /// </remarks>
     internal static readonly Logger _log = LogManager.GetLogger("logTemp");
 
+    internal static string GetPermanentLogFilePath()
+    {
+        return string.IsNullOrEmpty(UserSettings.Setting!.LogFile)
+            ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Desktop), "GetMyIP.log")
+            : UserSettings.Setting.LogFile;
+    }
+
     #region Create the NLog configuration
     /// <summary>
     /// Configure NLog
@@ -53,9 +60,7 @@ internal static class NLogHelpers
         #region Permanent log file
         // create log file Target for NLog
 
-        string permLogFile = string.IsNullOrEmpty(UserSettings.Setting!.LogFile)
-            ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Desktop), "GetMyIP.log")
-            : UserSettings.Setting.LogFile;
+        string permLogFile = GetPermanentLogFilePath();
 
         FileTarget logperm = new("logPerm")
         {
@@ -99,7 +104,7 @@ internal static class NLogHelpers
         #endregion Debugger
 
         // Lastly, set the logging level based on setting
-        SetLogLevel(UserSettings.Setting.IncludeDebug);
+        SetLogLevel(UserSettings.Setting!.IncludeDebug);
     }
     #endregion Create the NLog configuration
 

--- a/GetMyIP/Inno_Setup/GetMyIPEx.iss
+++ b/GetMyIP/Inno_Setup/GetMyIPEx.iss
@@ -119,6 +119,7 @@ Source: "{#MySourceDir}\Strings.test.xaml"; DestDir: "{app}"; Flags: ignoreversi
 ; Delete these files & folders from previous installs
 Type: filesandordirs; Name: "{group}"
 Type: files; Name: "{app}\CommandLine.dll"
+Type: files; Name: "{app}\CommandLineArgumentsParser.dll"
 Type: files; Name: "{app}\CommunityToolkit.WinUI.Notifications.dll"
 Type: files; Name: "{app}\MaterialDesignExtensions.dll"
 Type: files; Name: "{app}\Newtonsoft.Json.dll"

--- a/GetMyIP/Readme.txt
+++ b/GetMyIP/Readme.txt
@@ -190,11 +190,9 @@ Get My IP was written by Tim Kennedy.
 
 Get My IP uses the following packages and applications:
 
-    * Flag icons originally from https://flagpedia.net then converted to 16x12 ico files.
+    * Flag icons originally from https://flagpedia.net then converted to 16x12 *.ico files.
 
     * Material Design in XAML Toolkit https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit
-
-    * CommandLineParser https://github.com/j-maly/CommandLineParser
 
     * CommunityToolkit.Mvvm https://github.com/CommunityToolkit/dotnet
 
@@ -207,8 +205,6 @@ Get My IP uses the following packages and applications:
     * Octokit https://github.com/octokit/octokit.net
 
     * Vanara https://github.com/dahall/vanara
-
-    * GitKraken was used for everything Git related. https://www.gitkraken.com/
 
     * Inno Setup was used to create the installer. https://jrsoftware.org/isinfo.php
 


### PR DESCRIPTION
This pull request replaces the CommandLineParser library with a custom command-line parser and updates related logic and documentation.
- CommandLineHelpers.cs: Refactored to use the new CommandLineOptionsParser for argument parsing.
- Added CommandLineOptionsParser.cs: Implements custom parsing for "hide" argument and error reporting.
- GlobalUsings.cs and project file: Removed CommandLineArgumentsParser package and related usings.
- Readme.txt: Updated to remove CommandLineParser references and clarify flag icon source.
- IpHelpers.cs: Added log entry for external IP info log file location.
- GetMyIPEx.iss: Remove unneeded dll during subsequent installation.