### PR TITLE
Warn users about HTTP usage and provider accuracy. Closes #248

### DIFF
--- a/GetMyIP/Constants/AppConstString.cs
+++ b/GetMyIP/Constants/AppConstString.cs
@@ -32,6 +32,9 @@ internal static class AppConstString
     /// <value>
     /// The URL including all of the parameters specified in the URL.
     /// </value>
+    /// <remarks>
+    /// HTTPS protocol is not used because ip-api.com does not support HTTPS for free users.
+    /// </remarks>
     public static string IpApiUrl { get; } = "http://ip-api.com/json/?fields=status,message,country,countryCode,continent,regionName,city,zip,lat,lon,timezone,offset,isp,asname,as,query";
 
     /// <summary>

--- a/GetMyIP/Languages/Strings.de-DE.xaml
+++ b/GetMyIP/Languages/Strings.de-DE.xaml
@@ -14,13 +14,14 @@
 
         Translation contributed by:  uDEV2019, Copilot App
 
-        Date last updated:           2026-08-08
+        Date last updated:           2026-08-14
 
         =======================================================================
 
     -->
 
     <!--  About Page  -->
+    <sys:String x:Key="About_AccuracyWarning">Die Genauigkeit der von diesen Anbietern bereitgestellten Informationen kann nicht garantiert werden.</sys:String>
     <sys:String x:Key="About_BuildDate">Erstellzeitpunkt</sys:String>
     <sys:String x:Key="About_CommitID">Commit-ID</sys:String>
     <sys:String x:Key="About_CommitIDToolTip">Vollständige Commit-ID:</sys:String>
@@ -34,6 +35,7 @@
     <sys:String x:Key="About_DocumentationText">Liesmich öffnen</sys:String>
     <sys:String x:Key="About_DocumentationToolTip">Liesmich ansehen</sys:String>
     <sys:String x:Key="About_GitHubToolTip">"Get My IP"-Seite auf Github besuchen</sys:String>
+    <sys:String x:Key="About_HttpWarning">Verwendet das HTTP-Protokoll.</sys:String>
     <sys:String x:Key="About_License">Lizenz</sys:String>
     <sys:String x:Key="About_LicenseText">Dieses Projekt ist unter den Bedingungen der MIT-Lizenz lizenziert.</sys:String>
     <sys:String x:Key="About_LicenseToolTip">Das Lizenzdokument ansehen</sys:String>
@@ -242,6 +244,7 @@
     <sys:String x:Key="SettingsItem_EnableRefreshTooltipLine2">externe IP-Informationen in dem unten angegebenen Intervall aktualisieren.</sys:String>
     <sys:String x:Key="SettingsItem_EnableIPv6Retry">Wiederholen, wenn der Anbieter eine externe IPv6-Adresse zurückgibt</sys:String>
     <sys:String x:Key="SettingsItem_EnableTrayIcon">In Infobereich minimieren</sys:String>
+    <sys:String x:Key="SettingsItem_HttpWarning">Dieser Anbieter verwendet HTTP anstelle von HTTPS, übertragene Daten werden nicht verschlüsselt.</sys:String>
     <sys:String x:Key="SettingsItem_IncludeDebug">Fehlermeldungen in die Protokolldatei einbeziehen</sys:String>
     <sys:String x:Key="SettingsItem_IncludeIPV6">Interne IPv6-Adressen einbeziehen</sys:String>
     <sys:String x:Key="SettingsItem_InitialPage">Anzuzeigende Startseite</sys:String>

--- a/GetMyIP/Languages/Strings.en-US.xaml
+++ b/GetMyIP/Languages/Strings.en-US.xaml
@@ -21,6 +21,7 @@
     -->
 
     <!--  About Page  -->
+    <sys:String x:Key="About_AccuracyWarning">Accuracy of the information provided by these providers cannot be guaranteed.</sys:String>
     <sys:String x:Key="About_BuildDate">Commit Date</sys:String>
     <sys:String x:Key="About_CommitID">Commit ID</sys:String>
     <sys:String x:Key="About_CommitIDToolTip">Full Commit ID:</sys:String>
@@ -34,6 +35,7 @@
     <sys:String x:Key="About_DocumentationText">Open the ReadMe file</sys:String>
     <sys:String x:Key="About_DocumentationToolTip">View the ReadMe file</sys:String>
     <sys:String x:Key="About_GitHubToolTip">Visit the Get My IP page on GitHub</sys:String>
+    <sys:String x:Key="About_HttpWarning">Uses HTTP protocol.</sys:String>
     <sys:String x:Key="About_License">License</sys:String>
     <sys:String x:Key="About_LicenseText">This project is licensed under the terms of the MIT license.</sys:String>
     <sys:String x:Key="About_LicenseToolTip">View the license document</sys:String>
@@ -240,6 +242,7 @@
     <sys:String x:Key="SettingsItem_EnableRefreshTooltipLine1">Enabling periodic refresh will cause Get My IP to refresh</sys:String>
     <sys:String x:Key="SettingsItem_EnableRefreshTooltipLine2">external IP information at the interval specified below.</sys:String>
     <sys:String x:Key="SettingsItem_EnableTrayIcon">Minimize to tray and enable tray icon</sys:String>
+    <sys:String x:Key="SettingsItem_HttpWarning">This provider uses HTTP rather than HTTPS, transmitted data is not encrypted.</sys:String>
     <sys:String x:Key="SettingsItem_IncludeDebug">Include debug level messages in log file</sys:String>
     <sys:String x:Key="SettingsItem_IncludeIPV6">Include internal IPV6 addresses</sys:String>
     <sys:String x:Key="SettingsItem_InitialPage">Initial page displayed</sys:String>
@@ -294,7 +297,7 @@
     <sys:String x:Key="SettingsItem_StartCentered">Start with window centered on screen</sys:String>
     <sys:String x:Key="SettingsItem_StartMinimized">Start Minimized</sys:String>
     <sys:String x:Key="SettingsItem_StartupDelaySecs">Initial delay (seconds)</sys:String>
-    <sys:String x:Key="SettingsItem_StartupDelayTooltip">Number of seconds to wait after the app launches before fetching IP information. A value of zero means no delay. 600 is the maximum value.</sys:String>
+    <sys:String x:Key="SettingsItem_StartupDelayTooltip" xml:space="preserve">Number of seconds to wait after the app launches before fetching IP information.&#x0A;A value of zero means no delay. 600 is the maximum value.</sys:String>
     <sys:String x:Key="SettingsItem_StartWithWindows">Start with Windows</sys:String>
     <sys:String x:Key="SettingsItem_Theme">Theme</sys:String>
     <sys:String x:Key="SettingsItem_TranslationToolTipLine1">Represents the number of strings in the current language compared to the default (en-US).</sys:String>
@@ -659,4 +662,11 @@
     <!-- A | MsgText_ExternalRequestCanceled -->
     <!-- A | MsgText_ExternalUnknown -->
     <!-- End of changes on 2026/08/12 @ 00:00 UTC -->
+
+    <!-- Begin changes on 2026/08/14 @ 00:00 UTC -->
+    <!-- A | About_AccuracyWarning -->
+    <!-- A | About_HttpWarning -->
+    <!-- A | SettingsItem_HttpWarning -->
+    <!-- U | SettingsItem_StartupDelayTooltip - Added xml:space="preserve" and line break character &#x0a; -->
+    <!-- End of changes on 2026/08/14 @ 00:00 UTC -->
 </ResourceDictionary>

--- a/GetMyIP/Languages/Strings.es-ES.xaml
+++ b/GetMyIP/Languages/Strings.es-ES.xaml
@@ -15,13 +15,14 @@
 
         Translation contributed by:  Timthreetwelve and Google Translate
 
-        Date last updated:           2026-08-08
+        Date last updated:           2026-08-14
 
         =======================================================================
 
     -->
 
     <!--  About Page  -->
+    <sys:String x:Key="About_AccuracyWarning">La precisión de la información proporcionada por estos proveedores no se puede garantizar.</sys:String>
     <sys:String x:Key="About_BuildDate">La fecha del commit</sys:String>
     <sys:String x:Key="About_CommitID">ID de commit</sys:String>
     <sys:String x:Key="About_CommitIDToolTip">ID de commit completo:</sys:String>
@@ -35,6 +36,7 @@
     <sys:String x:Key="About_DocumentationText">Abrir el archivo Léame</sys:String>
     <sys:String x:Key="About_DocumentationToolTip">Ver el archivo Léame</sys:String>
     <sys:String x:Key="About_GitHubToolTip">Visitar la página de Get My IP en GitHub</sys:String>
+    <sys:String x:Key="About_HttpWarning">Usa el protocolo HTTP.</sys:String>
     <sys:String x:Key="About_License">Licencia</sys:String>
     <sys:String x:Key="About_LicenseText">Este proyecto está de acuerdo con los términos de la licencia MIT.</sys:String>
     <sys:String x:Key="About_LicenseToolTip">Ver el documento de licencia</sys:String>
@@ -240,6 +242,7 @@
     <sys:String x:Key="SettingsItem_EnableRefreshTooltipLine1">Habilitar la actualización periódica hará que Get My IP se actualice</sys:String>
     <sys:String x:Key="SettingsItem_EnableRefreshTooltipLine2">la información de IP externa en el intervalo especificado abajo.</sys:String>
     <sys:String x:Key="SettingsItem_EnableTrayIcon">Minimizar a bandeja y habilitar icono de bandeja</sys:String>
+    <sys:String x:Key="SettingsItem_HttpWarning">Este proveedor utiliza HTTP en lugar de HTTPS, los datos transmitidos no están encriptados.</sys:String>
     <sys:String x:Key="SettingsItem_IncludeDebug">Incluir mensajes de nivel de depuración en el archivo de registro</sys:String>
     <sys:String x:Key="SettingsItem_IncludeIPV6">Incluir direcciones IPV6 internas</sys:String>
     <sys:String x:Key="SettingsItem_InitialPage">Página inicial mostrada</sys:String>

--- a/GetMyIP/Languages/Strings.sk-SK.xaml
+++ b/GetMyIP/Languages/Strings.sk-SK.xaml
@@ -14,13 +14,14 @@
 
         Translation contributed by:  VAIO, Copilot App
 
-        Date last updated:           08.08.2026
+        Date last updated:           14.08.2026
 
         =======================================================================
 
     -->
 
     <!--  About Page  -->
+    <sys:String x:Key="About_AccuracyWarning">Presnosť informácií poskytnutých týmito poskytovateľmi nemôže byť zaručená.</sys:String>
 	<sys:String x:Key="About_BuildDate">Dátum zostavenia</sys:String>
     <sys:String x:Key="About_CommitID">ID potvrdenia</sys:String>
     <sys:String x:Key="About_CommitIDToolTip">Úplné ID záväzkov:</sys:String>
@@ -34,6 +35,7 @@
     <sys:String x:Key="About_DocumentationText">Otvorte súbor ReadMe</sys:String>
     <sys:String x:Key="About_DocumentationToolTip">Zobraziť súbor ReadMe</sys:String>
     <sys:String x:Key="About_GitHubToolTip">Navštívte stránku Get My IP na GitHub</sys:String>
+    <sys:String x:Key="About_HttpWarning">Používa protokol HTTP.</sys:String>
     <sys:String x:Key="About_License">Licencia</sys:String>
     <sys:String x:Key="About_LicenseText">Tento projekt je licencovaný podľa podmienok licencie MIT.</sys:String>
     <sys:String x:Key="About_LicenseToolTip">Zobraziť licenčný dokument</sys:String>
@@ -241,6 +243,7 @@
     <sys:String x:Key="SettingsItem_EnableRefreshTooltipLine1">Povolenie periodického obnovenia spôsobí, že Get My IP obnoví</sys:String>
     <sys:String x:Key="SettingsItem_EnableRefreshTooltipLine2">informácie o externej IP v nižšie uvedenom intervale.</sys:String>
     <sys:String x:Key="SettingsItem_EnableTrayIcon">Minimalizovať na panel a povoliť ikonu na paneli</sys:String>
+    <sys:String x:Key="SettingsItem_HttpWarning">Tento poskytovateľ používa HTTP namiesto HTTPS, prenášané údaje nie sú šifrované.</sys:String>
     <sys:String x:Key="SettingsItem_IncludeDebug">Zahrnúť správy na úrovni ladenia do súboru denníka</sys:String>
     <sys:String x:Key="SettingsItem_IncludeIPV6">Zahrnúť interné adresy IPV6</sys:String>
     <sys:String x:Key="SettingsItem_InitialPage">Zobrazená úvodná stránka</sys:String>

--- a/GetMyIP/Readme.txt
+++ b/GetMyIP/Readme.txt
@@ -29,13 +29,19 @@ centered on the longitude and latitude pulled from the external IP information.
 Next to the map icon is a refresh icon. Click on it to refresh all IP address information.
 
 
-Limitations
-===========
+Provider Limitations, Accuracy, and Security 
+============================================
 Get My IP employs several (user-selectable) sources to offer geolocation and external IP address
 information. These sites don't require the usage of an API key and offer the geolocation data
 for free. They don't charge for this data, but most do have a cap on the number of requests
 that may be made. For information on the restrictions set by each provider, see Limitations
-on the About page.
+on the About page. 
+
+The information provided by these sites is not guaranteed to be accurate. Furthermore, Get My IP
+cannot change the information provided by these sites.
+
+Additionally, some providers may rely on the HTTP protocol, which is not secure. If that’s a
+concern for you, consider choosing a different provider.
 
 
 The Pages
@@ -79,12 +85,12 @@ There are six sections on the Settings page. Click on the chevron on the right t
 
     UI settings
     -----------
-    Here you will find options to set the theme (Light, Material Dark, Darker, or System), the UI size,
-    the accent color, the font used to display the information, the font size, and row spacing. There
-    are also options to start the application centered on the screen, to restore a minimized window to the
-    center of the screen, to show the initial screen when restoring a minimized window, to automatically
-    reposition a window that is partially or completely off-screen back on-screen, and to keep the window
-    on top of other applications. You can choose to show or hide Exit in the navigation bar.
+    Here you will find options to set the theme (Light, Pale Graphite, Material Dark, Darker, Midnight Blue
+    or System), the UI size, the accent color, the font used to display the information, the font size, and
+    row spacing. There are also options to start the application centered on the screen, to restore a minimized
+    window to the center of the screen, to show the initial screen when restoring a minimized window, to
+    automatically reposition a window that is partially or completely off-screen back on-screen, and to keep
+    the window on top of other applications. You can choose to show or hide Exit in the navigation bar.
 
     Tray Icon Settings
     ------------------

--- a/GetMyIP/Views/AboutPage.xaml
+++ b/GetMyIP/Views/AboutPage.xaml
@@ -240,11 +240,13 @@
                             <RowDefinition Height="26" />
                             <RowDefinition Height="26" />
                             <RowDefinition Height="20" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="20" />
                         </Grid.RowDefinitions>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="20" />
-                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="30" />
+                            <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
                         <!--#endregion-->
 
@@ -270,6 +272,9 @@
                         <TextBlock Grid.Row="1" Grid.Column="2">
                             <Run Text="{DynamicResource About_LimitsToolTipLine1}" />
                             <Run Text="{DynamicResource About_LimitsToolTipLine2}" />
+                            <Run Text="- " />
+                            <Run Foreground="{DynamicResource MaterialDesign.Brush.Secondary}"
+                                 Text="{DynamicResource About_HttpWarning}" />
                         </TextBlock>
 
                         <TextBlock Grid.Row="2" Grid.Column="0">
@@ -294,8 +299,17 @@
                         <TextBlock Grid.Row="3" Grid.Column="2"
                                    Text="{DynamicResource About_LimitsToolTipLine7}" />
 
+                        <Grid Grid.Row="5" Grid.Column="0"
+                              Grid.ColumnSpan="3">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <TextBlock HorizontalAlignment="Left"
+                                       FontWeight="SemiBold"
+                                       Text="{DynamicResource About_AccuracyWarning}"
+                                       TextWrapping="Wrap" />
+                        </Grid>
                     </Grid>
-
                 </Expander>
                 <!--#endregion-->
 

--- a/GetMyIP/Views/SettingsPage.xaml
+++ b/GetMyIP/Views/SettingsPage.xaml
@@ -93,17 +93,17 @@
                     <Grid Grid.Row="0" Grid.Column="1">
                         <!--#region Row & Column definitions-->
                         <Grid.RowDefinitions>
-                            <RowDefinition Height="38" />
-                            <RowDefinition Height="38" />
-                            <RowDefinition Height="38" />
-                            <RowDefinition Height="40" />
-                            <RowDefinition Height="38" />
-                            <RowDefinition Height="38" />
+                            <RowDefinition Height="Auto" MinHeight="38" />
+                            <RowDefinition Height="Auto" MinHeight="38" />
+                            <RowDefinition Height="Auto" MinHeight="38" />
+                            <RowDefinition Height="Auto" MinHeight="38" />
+                            <RowDefinition Height="Auto" MinHeight="38" />
+                            <RowDefinition Height="Auto" MinHeight="38" />
                         </Grid.RowDefinitions>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto" />
                             <ColumnDefinition Width="10" />
-                            <ColumnDefinition />
+                            <ColumnDefinition Width="*" />
                         </Grid.ColumnDefinitions>
                         <!--#endregion-->
 
@@ -122,15 +122,29 @@
                         <Label Grid.Row="1" Grid.Column="0"
                                VerticalAlignment="Center"
                                Content="{DynamicResource SettingsItem_PublicInfoProvider}" />
-                        <ComboBox Grid.Row="1" Grid.Column="2"
-                                  Width="Auto" MinWidth="120"
-                                  Margin="0,3,0,0" Padding="3,0,0,3"
-                                  HorizontalAlignment="Left"
-                                  ItemsSource="{Binding Source={converters:EnumBindingSource {x:Type models:PublicInfoProvider}}}"
-                                  SelectedItem="{Binding InfoProvider,
-                                                         Source={x:Static config:UserSettings.Setting}}"
-                                  Style="{StaticResource MaterialDesignComboBox}" />
-
+                        <Grid Grid.Row="1" Grid.Column="2">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="20" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                                <ComboBox Width="Auto" MinWidth="120" Grid.Column="0"
+                                      Margin="0,3,0,0" Padding="3,0,0,3"
+                                      HorizontalAlignment="Left"
+                                      ItemsSource="{Binding Source={converters:EnumBindingSource {x:Type models:PublicInfoProvider}}}"
+                                      SelectedItem="{Binding InfoProvider,
+                                                             Source={x:Static config:UserSettings.Setting}}"
+                                      Style="{StaticResource MaterialDesignComboBox}" />
+                            <TextBlock HorizontalAlignment="Left" Grid.Column="2" 
+                                       VerticalAlignment="Center"
+                                       Text="{DynamicResource SettingsItem_HttpWarning}"
+                                       Foreground="{DynamicResource MaterialDesign.Brush.Secondary}"
+                                       TextWrapping="Wrap"
+                                       Visibility="{Binding InfoProvider,
+                                                            Source={x:Static config:UserSettings.Setting},
+                                                            Converter={StaticResource EnumToVisibility},
+                                                            ConverterParameter={x:Static models:PublicInfoProvider.IpApiCom}}" />
+                        </Grid>
                         <Label Grid.Row="2" Grid.Column="0"
                                VerticalAlignment="Center"
                                Content="{DynamicResource SettingsItem_MapProvider}" />
@@ -148,7 +162,7 @@
                                Content="{DynamicResource SettingsItem_RetryMax}" />
                         <StackPanel Grid.Row="3" Grid.Column="2"
                                     Orientation="Horizontal">
-                            <materialDesign:NumericUpDown Width="Auto" MinWidth="120"
+                            <materialDesign:NumericUpDown Width="Auto" MinWidth="120" MinHeight="27"
                                                           Margin="0,4,0,10" Padding="5,0,0,2"
                                                           HorizontalAlignment="Left"
                                                           VerticalContentAlignment="Bottom"
@@ -345,40 +359,40 @@
                                   SelectedItem="{Binding UITheme,
                                                          Source={x:Static config:UserSettings.Setting}}"
                                   Style="{StaticResource SettingsComboBox}" />
-                        
+
                         <Label Grid.Row="1" Grid.Column="0"
-                                   VerticalAlignment="Center"
-                                   Content="{DynamicResource SettingsItem_LightModeTheme}"
-                                   Visibility="{Binding UITheme,
-                                                        Source={x:Static config:UserSettings.Setting},
-                                                        Converter={StaticResource EnumToVisibility},
-                                                        ConverterParameter={x:Static models:ThemeType.System}}" />
+                               VerticalAlignment="Center"
+                               Content="{DynamicResource SettingsItem_LightModeTheme}"
+                               Visibility="{Binding UITheme,
+                                                    Source={x:Static config:UserSettings.Setting},
+                                                    Converter={StaticResource EnumToVisibility},
+                                                    ConverterParameter={x:Static models:ThemeType.System}}" />
                         <ComboBox Grid.Row="1" Grid.Column="2"
-                                      ItemsSource="{Binding SystemThemeTypes}"
-                                      SelectedItem="{Binding SystemLightTheme,
-                                                             Source={x:Static config:UserSettings.Setting}}"
-                                      Style="{StaticResource SettingsComboBox}"
-                                      Visibility="{Binding UITheme,
-                                                           Source={x:Static config:UserSettings.Setting},
-                                                           Converter={StaticResource EnumToVisibility},
-                                                           ConverterParameter={x:Static models:ThemeType.System}}" />
+                                  ItemsSource="{Binding SystemThemeTypes}"
+                                  SelectedItem="{Binding SystemLightTheme,
+                                                         Source={x:Static config:UserSettings.Setting}}"
+                                  Style="{StaticResource SettingsComboBox}"
+                                  Visibility="{Binding UITheme,
+                                                       Source={x:Static config:UserSettings.Setting},
+                                                       Converter={StaticResource EnumToVisibility},
+                                                       ConverterParameter={x:Static models:ThemeType.System}}" />
 
                         <Label Grid.Row="2" Grid.Column="0"
-                                   VerticalAlignment="Center"
-                                   Content="{DynamicResource SettingsItem_DarkModeTheme}"
-                                   Visibility="{Binding UITheme,
-                                                        Source={x:Static config:UserSettings.Setting},
-                                                        Converter={StaticResource EnumToVisibility},
-                                                        ConverterParameter={x:Static models:ThemeType.System}}" />
+                               VerticalAlignment="Center"
+                               Content="{DynamicResource SettingsItem_DarkModeTheme}"
+                               Visibility="{Binding UITheme,
+                                                    Source={x:Static config:UserSettings.Setting},
+                                                    Converter={StaticResource EnumToVisibility},
+                                                    ConverterParameter={x:Static models:ThemeType.System}}" />
                         <ComboBox Grid.Row="2" Grid.Column="2"
-                                      ItemsSource="{Binding SystemThemeTypes}"
-                                      SelectedItem="{Binding SystemDarkTheme,
-                                                             Source={x:Static config:UserSettings.Setting}}"
-                                      Style="{StaticResource SettingsComboBox}"
-                                      Visibility="{Binding UITheme,
-                                                           Source={x:Static config:UserSettings.Setting},
-                                                           Converter={StaticResource EnumToVisibility},
-                                                           ConverterParameter={x:Static models:ThemeType.System}}" />
+                                  ItemsSource="{Binding SystemThemeTypes}"
+                                  SelectedItem="{Binding SystemDarkTheme,
+                                                         Source={x:Static config:UserSettings.Setting}}"
+                                  Style="{StaticResource SettingsComboBox}"
+                                  Visibility="{Binding UITheme,
+                                                       Source={x:Static config:UserSettings.Setting},
+                                                       Converter={StaticResource EnumToVisibility},
+                                                       ConverterParameter={x:Static models:ThemeType.System}}" />
 
                         <Label Grid.Row="3" Grid.Column="0"
                                VerticalAlignment="Center"
@@ -387,7 +401,7 @@
                                   ItemsSource="{Binding Source={converters:EnumBindingSource {x:Type models:MySize}}}"
                                   SelectedItem="{Binding UISize,
                                                          Source={x:Static config:UserSettings.Setting}}"
-                                      Style="{StaticResource SettingsComboBox}"/>
+                                  Style="{StaticResource SettingsComboBox}" />
 
                         <Label Grid.Row="4" Grid.Column="0"
                                VerticalAlignment="Center"
@@ -413,8 +427,7 @@
                                VerticalAlignment="Center"
                                Content="{DynamicResource SettingsItem_DisplayFontSize}" />
                         <materialDesign:NumericUpDown Grid.Row="6" Grid.Column="2"
-                                                      MinWidth="200"
-                                                      Height="33"
+                                                      Height="33" MinWidth="200"
                                                       Margin="0,4" Padding="3,0,0,0"
                                                       HorizontalAlignment="Left"
                                                       VerticalContentAlignment="Center"
@@ -770,10 +783,11 @@
                         </Grid.ColumnDefinitions>
                         <!--#endregion-->
 
-                        <CheckBox Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="3"
-                                  HorizontalAlignment="Left"
+                        <CheckBox Grid.Row="0" Grid.Column="0"
+                                  Grid.ColumnSpan="3"
                                   Width="auto"
                                   Padding="10,0"
+                                  HorizontalAlignment="Left"
                                   Content="{DynamicResource SettingsItem_EnableIPv6Retry}"
                                   IsChecked="{Binding RetryIfIpv6,
                                                       Source={x:Static config:UserSettings.Setting}}" />


### PR DESCRIPTION
Warn users about HTTP usage and provider accuracy. Closes #248

- Added warning strings and UI elements to inform users about geolocation provider accuracy and HTTP usage.
- Updated English, German, Spanish, and Slovak translations.
- About and Settings pages now display relevant warnings.
- Updated Readme to clarify provider limitations, accuracy, security, and new UI themes.