### PR TITLE
Show periodic refresh icon, improve refresh UX & messages

### DIFF
--- a/GetMyIP/Configuration/SettingChange.cs
+++ b/GetMyIP/Configuration/SettingChange.cs
@@ -59,9 +59,11 @@ public static class SettingChange
             case nameof(UserSettings.Setting.InfoProvider):
                 _ = IpHelpers.CancelExternalInfoRequest("External info provider changed.");
                 _ = NavigationViewModel.RefreshIpInfo();
+                SettingsViewModel.UpdateRefresh();
                 break;
 
             case nameof(UserSettings.Setting.AutoRefreshInterval):
+            case nameof(UserSettings.Setting.AutoRefresh):
                 SettingsViewModel.UpdateRefresh();
                 break;
 

--- a/GetMyIP/Dialogs/SnackBarMsg.cs
+++ b/GetMyIP/Dialogs/SnackBarMsg.cs
@@ -43,4 +43,18 @@ public static class SnackBarMsg
         });
     }
     #endregion Clear message queue then queue a message and set duration
+
+    #region Queue a message without clearing the message queue (default duration)
+    /// <summary>
+    /// Queues a message (default duration) without clearing the message queue.
+    /// </summary>
+    /// <param name="message">The message.</param>
+    public static void QueueMessageNoClear(string message)
+    {
+        Application.Current.Dispatcher.Invoke(() =>
+        {
+            (Application.Current.MainWindow as MainWindow)?.SnackBar1.MessageQueue!.Enqueue(message);
+        });
+    }
+    #endregion Queue a message without clearing the message queue (default duration)
 }

--- a/GetMyIP/Helpers/RefreshHelpers.cs
+++ b/GetMyIP/Helpers/RefreshHelpers.cs
@@ -14,7 +14,7 @@ internal static class RefreshHelpers
         int intervalMinutes = (int)UserSettings.Setting!.AutoRefreshInterval;
         if (intervalMinutes < 1)
         {
-            _log.Debug($"Invalid refresh timer interval - {intervalMinutes}");
+            _log.Warn($"Invalid refresh timer interval - {intervalMinutes}");
             return;
         }
         TimeSpan interval = TimeSpan.FromMinutes(intervalMinutes);
@@ -25,13 +25,13 @@ internal static class RefreshHelpers
         };
         if (!_refreshTimer.Enabled)
         {
-            _refreshTimer.Elapsed += TimerElapsed!;
+            _refreshTimer.Elapsed += TimerElapsed;
             _refreshTimer.Start();
-            RefreshInfo.Instance.LastRefresh = DateTime.Now.ToString("g", CultureInfo.CurrentCulture);
-            _log.Debug($"Periodic refresh timer started. Refresh interval is {intervalMinutes} minutes");
-            SnackBarMsg.ClearAndQueueMessage("Periodic Refresh started.");
-        }
 
+            RefreshInfo.Instance.LastRefresh = DateTime.Now.ToString("g", CultureInfo.CurrentCulture);
+            _log.Info($"Periodic refresh timer started. Refresh interval is {intervalMinutes} minutes");
+            SnackBarMsg.ClearAndQueueMessage(GetStringResource("MsgText_PeriodicRefreshStarted"));
+        }
     }
     #endregion Start the refresh timer
 
@@ -41,21 +41,21 @@ internal static class RefreshHelpers
         if (_refreshTimer?.Enabled == true)
         {
             _refreshTimer.Stop();
-            _refreshTimer.Elapsed -= TimerElapsed!;
+            _refreshTimer.Elapsed -= TimerElapsed;
             _refreshTimer.Dispose();
             _refreshTimer = null;
-            _log.Debug("Periodic refresh timer stopped");
-            SnackBarMsg.ClearAndQueueMessage("Periodic refresh stopped.");
+            _log.Info("Periodic refresh timer stopped");
+            SnackBarMsg.ClearAndQueueMessage(GetStringResource("MsgText_PeriodicRefreshStopped"));
         }
     }
     #endregion Stop the timer
 
     #region Timer elapsed
-    private static async void TimerElapsed(object sender, System.Timers.ElapsedEventArgs e)
+    private static async void TimerElapsed(object? sender, System.Timers.ElapsedEventArgs e)
     {
         try
         {
-            _log.Debug("Periodic IP address refresh starting");
+            _log.Info("Periodic IP address refresh starting");
             await NavigationViewModel.RefreshExternalAsync();
             RefreshInfo.Instance.LastRefresh = DateTime.Now.ToString("g", CultureInfo.CurrentCulture);
             CompareIP();

--- a/GetMyIP/Languages/Strings.en-US.xaml
+++ b/GetMyIP/Languages/Strings.en-US.xaml
@@ -183,6 +183,7 @@
     <sys:String x:Key="MsgText_MaxRetriesReached">Maximum retry count ({0}) reached.</sys:String>
     <sys:String x:Key="MsgText_OpeningLogFile">Opening the log file</sys:String>
     <sys:String x:Key="MsgText_OpeningReadMeFile">Opening the ReadMe file</sys:String>
+    <sys:String x:Key="MsgText_PeriodicRefreshEnabled">Periodic Refresh is enabled</sys:String>
     <sys:String x:Key="MsgText_PeriodicRefreshStarted">Periodic Refresh started</sys:String>
     <sys:String x:Key="MsgText_PeriodicRefreshStopped">Periodic Refresh stopped</sys:String>
     <sys:String x:Key="MsgText_Refreshed">Refreshed</sys:String>
@@ -669,4 +670,9 @@
     <!-- A | SettingsItem_HttpWarning -->
     <!-- U | SettingsItem_StartupDelayTooltip - Added xml:space="preserve" and line break character &#x0a; -->
     <!-- End of changes on 2026/08/14 @ 00:00 UTC -->
+    
+    <!-- Begin changes on 2026/08/24 @ 00:00 UTC -->
+    <!-- A | MsgText_PeriodicRefreshEnabled - Translate as "Periodic Refresh" or "Automatic Refresh",
+                                              whichever is more appropriate in your local context -->
+    <!-- End of changes on 2026/08/24 @ 00:00 UTC -->
 </ResourceDictionary>

--- a/GetMyIP/MainWindow.xaml
+++ b/GetMyIP/MainWindow.xaml
@@ -84,7 +84,7 @@
             <!--#region Column definitions for the title row-->
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="115" />
+                <ColumnDefinition Width="140" />
             </Grid.ColumnDefinitions>
             <!--#endregion-->
 
@@ -113,10 +113,24 @@
                         Margin="0,0,5,0"
                         HorizontalAlignment="Right"
                         Orientation="Horizontal">
+
+                <!--#region Periodic Refresh icon-->
+                <TextBlock Width="30"
+                           VerticalAlignment="Center"
+                           Foreground="{DynamicResource MaterialDesign.Brush.Foreground}"
+                           ToolTip="{DynamicResource MsgText_PeriodicRefreshEnabled}"
+                           Visibility="{Binding Source={x:Static config:UserSettings.Setting},
+                                                Path=AutoRefresh,
+                                                Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <materialDesign:PackIcon Width="24" Height="24"
+                                             Kind="RefreshAuto" />
+                </TextBlock>
+                <!--#endregion-->
+
                 <!--#region Refresh and Cancel buttons-->
                 <Grid>
                     <Button x:Name="CancelButton"
-                            Width="40"
+                            Width="30"
                             Margin="0" Padding="0"
                             HorizontalAlignment="Left"
                             Command="{Binding CancelExternalInfoRequestCommand}"
@@ -127,10 +141,10 @@
                             Visibility="{Binding IsExternalRequestInProgress,
                                                  Converter={StaticResource BooleanToVisibilityConverter}}">
                         <materialDesign:PackIcon Width="24" Height="24"
-                                                 Kind="CancelBold" />
+                                                 Kind="Refresh" />
                     </Button>
 
-                    <Button Width="40"
+                    <Button Width="30"
                             Margin="0" Padding="0"
                             HorizontalAlignment="Left"
                             Command="{Binding RefreshFromButtonCommand}"
@@ -148,8 +162,8 @@
                 <!--#endregion-->
 
                 <!--#region Show Map button-->
-                <Button Width="40"
-                        Margin="0" Padding="0"
+                <Button Width="30"
+                        Margin="3,0,4,0" Padding="0"
                         HorizontalAlignment="Left"
                         Command="{Binding ShowMapCommand}"
                         Foreground="{DynamicResource MaterialDesign.Brush.Foreground}"
@@ -165,7 +179,8 @@
                 <!--#endregion-->
 
                 <!--#region Three-dot Menu under popup-->
-                <materialDesign:PopupBox Padding="0" HorizontalAlignment="Right"
+                <materialDesign:PopupBox Height="30"
+                                         Padding="0" HorizontalAlignment="Right"
                                          Focusable="False"
                                          PlacementMode="LeftAndAlignTopEdges"
                                          ToolTip="{DynamicResource Button_ThreeDotToolTip}">
@@ -180,7 +195,7 @@
                             BorderThickness="2">
                         <Grid Width="Auto">
                             <StackPanel Orientation="Vertical">
-                                <Button Height="35"
+                                <Button Height="40"
                                         Padding="15,1,15,12"
                                         Command="{Binding StopRefreshCommand}"
                                         Content="{DynamicResource Button_StopRefresh}"

--- a/GetMyIP/Models/RefreshInfo.cs
+++ b/GetMyIP/Models/RefreshInfo.cs
@@ -8,10 +8,10 @@ public partial class RefreshInfo : ObservableObject
 #pragma warning disable MVVMTK0042 // Prefer using [ObservableProperty] on partial properties
     // Suppressing the MVVMTK0042 warning for this class until such time as it no longer requires Preview features.
     [ObservableProperty]
-    private string? _lastRefresh;
+    private string _lastRefresh = GetStringResource("MsgText_ExternalUnknown");
 
     [ObservableProperty]
-    private string? _lastIPAddress = string.Empty;
+    private string _lastIPAddress = string.Empty;
 #pragma warning restore MVVMTK0042 // Prefer using [ObservableProperty] on partial properties
     #endregion Properties
 

--- a/GetMyIP/ViewModels/NavigationViewModel.cs
+++ b/GetMyIP/ViewModels/NavigationViewModel.cs
@@ -298,7 +298,7 @@ internal sealed partial class NavigationViewModel : ObservableObject
         TrayIconHelpers.SetTrayIcon();
         if (_mainWindow!.Visibility == Visibility.Visible)
         {
-            SnackBarMsg.ClearAndQueueMessage(GetStringResource("MsgText_Refreshed"));
+            SnackBarMsg.QueueMessageNoClear(GetStringResource("MsgText_Refreshed"));
         }
     }
     #endregion Refresh (Used by refresh button and tray context menu)
@@ -318,7 +318,7 @@ internal sealed partial class NavigationViewModel : ObservableObject
         TrayIconHelpers.SetTrayIcon();
         if (_mainWindow!.Visibility == Visibility.Visible)
         {
-            SnackBarMsg.ClearAndQueueMessage(GetStringResource("MsgText_Refreshed"));
+            SnackBarMsg.QueueMessageNoClear(GetStringResource("MsgText_Refreshed"));
         }
     }
     #endregion Refresh external IP address info

--- a/GetMyIP/ViewModels/SettingsViewModel.cs
+++ b/GetMyIP/ViewModels/SettingsViewModel.cs
@@ -196,7 +196,11 @@ public partial class SettingsViewModel : ObservableObject
             RefreshHelpers.StopTimer();
             Task.Delay(50).Wait();
             RefreshHelpers.StartTimer();
-            SnackBarMsg.ClearAndQueueMessage(GetStringResource("MsgText_Refreshed"));
+            SnackBarMsg.QueueMessageNoClear(GetStringResource("MsgText_Refreshed"));
+        }
+        else
+        { 
+            RefreshHelpers.StopTimer();
         }
     }
 


### PR DESCRIPTION
Show periodic refresh icon, improve refresh UX & messages

- Fix enable/disable periodic refresh when state changes from Settings page
- Add visible "Periodic Refresh" icon with tooltip in MainWindow when auto-refresh is enabled
- Resize refresh/map buttons for compact layout and adjust spacing
- Use localized strings for refresh messages; log at Info level
- Update timer event handler for nullability
- Initialize RefreshInfo.LastRefresh with default localized string
- Allow SnackBarMsg to queue messages without clearing queue for refresh notifications
- Only clear/queue message in SettingsViewModel.UpdateRefresh if auto-refresh is enabled
- Add "Periodic Refresh is enabled" string to Strings.en-US.xaml and document change
- Minor UI tweaks in MainWindow.xaml

Closes #265