### PR TITLE
Update resource files: date, new string, remove provider

### DIFF
--- a/GetMyIP/Languages/Strings.de-DE.xaml
+++ b/GetMyIP/Languages/Strings.de-DE.xaml
@@ -14,7 +14,7 @@
 
         Translation contributed by:  uDEV2019, Copilot App
 
-        Date last updated:           2026-08-14
+        Date last updated:           2026-08-24
 
         =======================================================================
 
@@ -47,8 +47,6 @@
     <sys:String x:Key="About_LimitsToolTipLine5">ip2location.io beschränkt die Nutzung</sys:String>
     <sys:String x:Key="About_LimitsToolTipLine6">auf 500 Anfragen pro Tag.</sys:String>
     <sys:String x:Key="About_LimitsToolTipLine7">seeip.org hat keine Beschränkungen.</sys:String>
-    <sys:String x:Key="About_LimitsToolTipLine8">ipwho.org beschränkt die Nutzung</sys:String>
-    <sys:String x:Key="About_LimitsToolTipLine9">auf 100,000 Anfragen pro Monat.</sys:String>
     <sys:String x:Key="About_LimitsUsage">Es gelten Nutzungsbeschränkungen.</sys:String>
     <sys:String x:Key="About_ProvidersLine1">IP-Informationsanbieter</sys:String>
     <sys:String x:Key="About_Translations">Übersetzungen</sys:String>
@@ -185,6 +183,7 @@
     <sys:String x:Key="MsgText_MaxRetriesReached">Maximale Wiederholungsanzahl ({0}) erreicht.</sys:String>
     <sys:String x:Key="MsgText_OpeningLogFile">Protokolldatei wird geöffnet</sys:String>
     <sys:String x:Key="MsgText_OpeningReadMeFile">Liesmich wird geöffnet</sys:String>
+    <sys:String x:Key="MsgText_PeriodicRefreshEnabled">Periodische Aktualisierung ist aktiviert</sys:String>
     <sys:String x:Key="MsgText_PeriodicRefreshStarted">Periodische Aktualisierung gestartet</sys:String>
     <sys:String x:Key="MsgText_PeriodicRefreshStopped">Periodische Aktualisierung beendet</sys:String>
     <sys:String x:Key="MsgText_Refreshed">Aktualisieren</sys:String>
@@ -340,7 +339,6 @@
     <sys:String x:Key="SettingsEnum_Navigation_Settings">Einstellungen</sys:String>
     <sys:String x:Key="SettingsEnum_Provider_Ip2Location">ip2location.io</sys:String>
     <sys:String x:Key="SettingsEnum_Provider_IpApiCom">ip-api.com</sys:String>
-    <sys:String x:Key="SettingsEnum_Provider_IpWhoOrg">ipwho.org</sys:String>
     <sys:String x:Key="SettingsEnum_Provider_FreeIpApi">freeipapi.com</sys:String>
     <sys:String x:Key="SettingsEnum_Provider_SeeIp">seeip.org</sys:String>
     <sys:String x:Key="SettingsEnum_RefreshInterval_1Minute">1 Minute</sys:String>

--- a/GetMyIP/Languages/Strings.es-ES.xaml
+++ b/GetMyIP/Languages/Strings.es-ES.xaml
@@ -15,7 +15,7 @@
 
         Translation contributed by:  Timthreetwelve and Google Translate
 
-        Date last updated:           2026-08-14
+        Date last updated:           2026-08-24
 
         =======================================================================
 
@@ -184,6 +184,7 @@
     <sys:String x:Key="MsgText_MaxRetriesReached">Se alcanzó el recuento máximo de reintentos ({0}).</sys:String>
     <sys:String x:Key="MsgText_OpeningLogFile">Abriendo el archivo de registro</sys:String>
     <sys:String x:Key="MsgText_OpeningReadMeFile">Abriendo el archivo ReadMe</sys:String>
+    <sys:String x:Key="MsgText_PeriodicRefreshEnabled">Actualización Periódica está habilitada</sys:String>
     <sys:String x:Key="MsgText_PeriodicRefreshStarted">Actualización Periódica iniciada</sys:String>
     <sys:String x:Key="MsgText_PeriodicRefreshStopped">Actualización Periódica detenida</sys:String>
     <sys:String x:Key="MsgText_Refreshed">Actualizado</sys:String>

--- a/GetMyIP/Languages/Strings.sk-SK.xaml
+++ b/GetMyIP/Languages/Strings.sk-SK.xaml
@@ -14,7 +14,7 @@
 
         Translation contributed by:  VAIO, Copilot App
 
-        Date last updated:           14.08.2026
+        Date last updated:           24.08.2026
 
         =======================================================================
 
@@ -184,6 +184,7 @@
     <sys:String x:Key="MsgText_MaxRetriesReached">Dosiahol sa maximálny počet pokusov ({0}).</sys:String>
     <sys:String x:Key="MsgText_OpeningLogFile">Otváranie súboru denníka</sys:String>
     <sys:String x:Key="MsgText_OpeningReadMeFile">Otvorenie súboru ReadMe</sys:String>
+    <sys:String x:Key="MsgText_PeriodicRefreshEnabled">Periodické obnovenie je povolené</sys:String>
     <sys:String x:Key="MsgText_PeriodicRefreshStarted">Periodické obnovenie začalo</sys:String>
     <sys:String x:Key="MsgText_PeriodicRefreshStopped">Periodické obnovenie bolo zastavené</sys:String>
     <sys:String x:Key="MsgText_Refreshed">Obnovené</sys:String>


### PR DESCRIPTION
Update resource files: date, new string, remove provider

- Added "Periodic Refresh Enabled" string in German, Spanish, and Slovak resource files.
- Removed "ipwho.org" provider and its tooltip from the German resource file.
- Updated "Date last updated" to 2026-08-24 in all three files.