### PR TITLE
Add PathHelpers.FindOnPath to increase resiliency and handle nonstandard file locations

### DIFF
--- a/GetMyIP/Helpers/PathHelpers.cs
+++ b/GetMyIP/Helpers/PathHelpers.cs
@@ -43,4 +43,52 @@ internal static class PathHelpers
 
         return $"%USERPROFILE%{path[userProfile.Length..]}";
     }
+
+    #region Search PATH for a file
+    /// <summary>
+    /// Find a file name in the path and optionally, the current directory.
+    /// </summary>
+    /// <param name="filename">File name to search for</param>
+    /// <param name="includeCurrentDirectory">Whether to include the current directory in the search</param>
+    /// <returns>Path to the file if found; otherwise, an empty string</returns>
+    /// <remarks>
+    /// This method searches for the specified file in the directories listed in the PATH environment variable.
+    /// If includeCurrentDirectory is true, it also searches in the current directory.
+    /// There are potential security risks associated with including the current directory in the search, as it
+    /// may lead to executing unintended files. Use this option with caution.
+    /// </remarks>
+    public static string FindOnPath(string filename, bool includeCurrentDirectory = false)
+    {
+        if (string.IsNullOrEmpty(filename) || filename.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+        {
+            throw new ArgumentException("Filename cannot be null, empty, or contain invalid characters.", nameof(filename));
+        }
+        if (Path.GetExtension(filename) == string.Empty)
+        {
+            throw new ArgumentException("Filename must have an extension.", nameof(filename));
+        }
+        if (Path.IsPathRooted(filename))
+        {
+            throw new ArgumentException("Filename must not be a rooted path.", nameof(filename));
+        }
+        string pathVar = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+        string[] folders = pathVar.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries);
+
+        if (includeCurrentDirectory)
+        {
+            folders = [Environment.CurrentDirectory, .. folders];
+        }
+
+        foreach (string folder in folders)
+        {
+            string path = Path.Combine(folder.Trim('\"'), filename);
+            if (File.Exists(path))
+            {
+                return path;
+            }
+        }
+
+        return string.Empty;
+    }
+    #endregion Search PATH for a file
 }

--- a/GetMyIP/Helpers/TextFileViewer.cs
+++ b/GetMyIP/Helpers/TextFileViewer.cs
@@ -28,23 +28,12 @@ internal static class TextFileViewer
             int ERROR_NO_ASSOCIATION = 1155;
             if (ex.NativeErrorCode == ERROR_NO_ASSOCIATION)
             {
-                string notepadPath = string.Empty;
-                string system32 = Environment.GetFolderPath(Environment.SpecialFolder.System);
-                string windir = Environment.GetEnvironmentVariable("windir") ?? "C:\\Windows";
-                
-                if (File.Exists(Path.Combine(system32, "notepad.exe")))
+                string notepadPath = PathHelpers.FindOnPath("notepad.exe", false);
+                if (string.IsNullOrEmpty(notepadPath))
                 {
-                    notepadPath = Path.Combine(system32, "notepad.exe");
-                }
-                else if (File.Exists(Path.Combine(windir, "notepad.exe")))
-                {
-                    notepadPath = Path.Combine(windir, "notepad.exe");
-                }
-                else
-                {
-                    _log.Error($"Unable to find notepad.exe in {system32} or {windir}");
+                    _log.Error($"Unable to find notepad.exe in PATH");
                     string msg = string.Format(CultureInfo.InvariantCulture, MsgTextErrorOpeningFile, textFile);
-                    _ = MessageBox.Show($"{msg}\n\nUnable to find notepad.exe in {system32} or {windir}",
+                    _ = MessageBox.Show($"{msg}\n\nUnable to find notepad.exe in PATH",
                                         GetStringResource("MsgText_Error_Caption"),
                                         MessageBoxButton.OK,
                                         MessageBoxImage.Error);

--- a/GetMyIP/ViewModels/SettingsViewModel.cs
+++ b/GetMyIP/ViewModels/SettingsViewModel.cs
@@ -94,7 +94,22 @@ public partial class SettingsViewModel : ObservableObject
             filePath = Path.Combine(AppInfo.AppDirectory, "Strings.test.xaml");
             if (File.Exists(filePath))
             {
-                _ = Process.Start("explorer.exe", $"/select,\"{filePath}\"");
+                string explorerPath = PathHelpers.FindOnPath("explorer.exe", false);
+                if (string.IsNullOrEmpty(explorerPath))
+                {
+                    _log.Error($"Error trying to open {filePath}: FindOnPath returned null or empty");
+                    string msg = $"{GetStringResource("MsgText_Error_FileExplorer")}" +
+                                 $"\n\n{GetStringResource("MsgText_Error_SeeLog")}";
+                    _ = new MDCustMsgBox(msg,
+                             GetStringResource("MsgText_Error_Caption"),
+                             ButtonType.Ok,
+                             false,
+                             true,
+                             _mainWindow,
+                             true).ShowDialog();
+                    return;
+                }
+                Process.Start(explorerPath, $"/select,\"{filePath}\"");
             }
             else
             {


### PR DESCRIPTION
Add PathHelpers.FindOnPath to increase resiliency and handle nonstandard file locations

- Added `PathHelpers.FindOnPath` to search for files in the system PATH, optionally including the current directory.
- Refactored TextFileViewer and SettingsViewModel to use this method for locating notepad.exe and explorer.exe, respectively.
- Improved error handling and user notification if explorer.exe is not found.