### PR TITLE
Add copy-to-clipboard icon for DataGrid cell values.

### DIFF
--- a/GetMyIP/Configuration/UserSettings.cs
+++ b/GetMyIP/Configuration/UserSettings.cs
@@ -215,6 +215,12 @@ public partial class UserSettings : ConfigManager<UserSettings>
     private bool _showCity;
 
     /// <summary>
+    /// Option to show Copy Icon in cell.
+    /// </summary>
+    [ObservableProperty]
+    private bool _showCopyIcon;
+
+    /// <summary>
     /// Option to show Country in results.
     /// </summary>
     [ObservableProperty]

--- a/GetMyIP/Configuration/UserSettings.cs
+++ b/GetMyIP/Configuration/UserSettings.cs
@@ -21,8 +21,11 @@ public partial class UserSettings : ConfigManager<UserSettings>
     [ObservableProperty]
     private bool _autoRefresh;
 
+    /// <summary>
+    /// The interval, in seconds, for periodic refresh.
+    /// </summary>
     [ObservableProperty]
-    private int _autoRefreshSeconds = TimeSpan.FromHours(1).Seconds;
+    private int _autoRefreshSeconds = 3600;
 
     /// <summary>
     ///  Used to determine if Debug level messages are included in the application log.

--- a/GetMyIP/Converters/BoolToVisibilityInverter.cs
+++ b/GetMyIP/Converters/BoolToVisibilityInverter.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Tim Kennedy. All Rights Reserved. Licensed under the MIT License.
+
+namespace GetMyIP.Converters;
+
+/// <summary>
+/// An inverse bool to visibility converter
+/// </summary>
+/// <seealso cref="System.Windows.Data.IValueConverter" />
+internal sealed class BoolToVisibilityInverter : IValueConverter
+{
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        return (bool)value! ? Visibility.Collapsed : Visibility.Visible;
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        return Binding.DoNothing;
+    }
+}

--- a/GetMyIP/Languages/Strings.en-US.xaml
+++ b/GetMyIP/Languages/Strings.en-US.xaml
@@ -285,6 +285,7 @@
     <sys:String x:Key="SettingsItem_ShowAsNumber">Show AS number</sys:String>
     <sys:String x:Key="SettingsItem_ShowCity">Show city</sys:String>
     <sys:String x:Key="SettingsItem_ShowCountry">Show country</sys:String>
+    <sys:String x:Key="SettingsItem_ShowCopyIcon">Show copy icon next to external and internal rows</sys:String>
     <sys:String x:Key="SettingsItem_ShowCustomHeader">Show custom header</sys:String>
     <sys:String x:Key="SettingsItem_ShowCustomHeaderHint">Custom header text</sys:String>
     <sys:String x:Key="SettingsItem_ShowExit">Show Exit in Navigation bar</sys:String>
@@ -677,4 +678,8 @@
     <!-- A | SettingsItem_RefreshIntervalSecondsSuffix -->
     <!-- A | SettingsItem_TimeSpinnerToolTipLine1 -->
     <!-- End of changes on 2026/09/05 @ 00:00 UTC -->
+    
+    <!-- Begin changes on 2026/09/07 @ 00:00 UTC -->
+    <!-- A | SettingsItem_ShowCopyIcon -->
+    <!-- End of changes on 2026/09/07 @ 00:00 UTC -->
 </ResourceDictionary>

--- a/GetMyIP/MainWindow.xaml
+++ b/GetMyIP/MainWindow.xaml
@@ -315,13 +315,6 @@
                     BorderThickness="1.5,1,0,0">
                 <ContentControl Content="{Binding CurrentViewModel}" />
             </Border>
-
-            <bh:Interaction.Triggers>
-                <bh:EventTrigger EventName="MouseRightButtonUp">
-                    <bh:InvokeCommandAction Command="{Binding RightMouseUpCommand}"
-                                            PassEventArgsToCommand="True" />
-                </bh:EventTrigger>
-            </bh:Interaction.Triggers>
         </Grid>
         <!--#endregion-->
 

--- a/GetMyIP/Styles/ButtonStyles.xaml
+++ b/GetMyIP/Styles/ButtonStyles.xaml
@@ -48,4 +48,23 @@
     </Style>
     <!--#endregion-->
 
+    <!--#region Copy to clipboard button style-->
+    <Style TargetType="Button"
+           x:Key="CopyToClipboardButton"
+           BasedOn="{StaticResource MaterialDesignPaperButton}">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderBrush" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Foreground" Value="{DynamicResource MaterialDesign.Brush.Foreground}" />
+        <Setter Property="Height" Value="18" />
+        <Setter Property="HorizontalAlignment" Value="Right" />
+        <Setter Property="Margin" Value="10,0" />
+        <Setter Property="Opacity" Value="0.8" />
+        <Setter Property="Padding" Value="0" />
+        <Setter Property="VerticalAlignment" Value="Center" />
+        <Setter Property="Width" Value="30" />
+        <Setter Property="materialDesign:RippleAssist.Feedback" Value="{DynamicResource MaterialDesign.Brush.Foreground}" />
+    </Style>
+    <!--#endregion-->
+
 </ResourceDictionary>

--- a/GetMyIP/ViewModels/NavigationViewModel.cs
+++ b/GetMyIP/ViewModels/NavigationViewModel.cs
@@ -373,43 +373,6 @@ internal sealed partial class NavigationViewModel : ObservableObject
     }
     #endregion Stop refresh timers
 
-    #region Right mouse button
-    /// <summary>
-    /// Copy (nearly) any text in a TextBlock to the clipboard on right mouse button up.
-    /// </summary>
-    [RelayCommand]
-    private static async Task RightMouseUp(MouseButtonEventArgs e)
-    {
-        if (e.OriginalSource is not TextBlock text)
-        {
-            return;
-        }
-
-        try
-        {
-            if (await ClipboardHelper.CopyTextToClipboardAsync(text.Text))
-            {
-                SnackBarMsg.ClearAndQueueMessage(GetStringResource("MsgText_CopiedToClipboard"));
-                _log.Debug($"{text.Text.Length} bytes copied to the clipboard");
-            }
-            else
-            {
-                _log.Error("RightMouseUp clipboard copy failed.");
-                SnackBarMsg.ClearAndQueueMessage(GetStringResource("MsgText_CopyToClipboardFail"));
-            }
-
-            DataGridRow dgr = MainWindowHelpers.FindParent<DataGridRow>(text);
-            dgr.IsSelected = false;
-            DataGrid dg = MainWindowHelpers.FindParent<DataGrid>(dgr);
-            dg.Items.Refresh();
-        }
-        catch (Exception ex)
-        {
-            _log.Error(ex, $"Right-click event handler failed. {ex.Message}");
-        }
-    }
-    #endregion Right mouse button
-
     #region Key down events
     /// <summary>
     /// Keyboard events
@@ -417,6 +380,7 @@ internal sealed partial class NavigationViewModel : ObservableObject
     [RelayCommand]
     private static async Task KeyDown(KeyEventArgs e)
     {
+
         // The case statements are in order by modifier keys (none, alt, control, control+shift), then key.
         // The underscore (_) is a discard for the value that is not needed.
         switch ((e.KeyboardDevice.Modifiers, e.Key, e.SystemKey))
@@ -427,6 +391,10 @@ internal sealed partial class NavigationViewModel : ObservableObject
 
             case (ModifierKeys.None, Key.F5, _):
                 _ = RefreshIpInfo();
+                break;
+
+            case (ModifierKeys.None, Key.Escape, _):
+                e.Handled = true;
                 break;
 
             case (ModifierKeys.Alt, _, Key.F4):
@@ -628,4 +596,37 @@ internal sealed partial class NavigationViewModel : ObservableObject
         }
     }
     #endregion Show snack bar message for UI changes
+
+    #region Copy DataGrid cell value
+    /// <summary>
+    /// Copy a DataGrid cell value to clipboard.
+    /// </summary>
+    [RelayCommand]
+    public static async Task CopyCellValue(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return;
+        }
+
+        try
+        {
+            if (await ClipboardHelper.CopyTextToClipboardAsync(text))
+            {
+                _log.Debug($"{text.Length} characters copied to the clipboard");
+                SnackBarMsg.ClearAndQueueMessage(GetStringResource("MsgText_CopiedToClipboard"));
+            }
+            else
+            {
+                _log.Error("CopyCellValue clipboard copy failed.");
+                SnackBarMsg.ClearAndQueueMessage(GetStringResource("MsgText_CopyToClipboardFail"));
+            }
+        }
+        catch (Exception ex)
+        {
+            _log.Error(ex, $"CopyCellValue command failed. {ex.Message}");
+            SnackBarMsg.ClearAndQueueMessage(GetStringResource("MsgText_CopyToClipboardFail"));
+        }
+    }
+    #endregion Copy DataGrid cell value
 }

--- a/GetMyIP/Views/ExtrernalInfoPage.xaml
+++ b/GetMyIP/Views/ExtrernalInfoPage.xaml
@@ -17,6 +17,8 @@
     <!--#region Resources-->
     <UserControl.Resources>
         <convert:SpacingConverter x:Key="Spacing" />
+        <convert:BoolToVisibilityInverter x:Key="BoolToVisInverter" />
+        <BooleanToVisibilityConverter x:Key="BoolToVisConverter" />
     </UserControl.Resources>
     <!--#endregion-->
 
@@ -36,12 +38,39 @@
                   IsReadOnly="True"
                   ItemsSource="{Binding Source={x:Static models:IPInfo.GeoInfoList}}"
                   SelectionMode="Single"
-                  SelectionUnit="Cell">
+                  SelectionUnit="FullRow">
             <DataGrid.Columns>
                 <DataGridTextColumn Binding="{Binding Parameter}"
                                     Header="{DynamicResource ColumnHead_Parameter}" />
                 <DataGridTextColumn Binding="{Binding Value}"
-                                    Header="{DynamicResource ColumnHead_Value}" />
+                                    Header="{DynamicResource ColumnHead_Value}"
+                                    Visibility="{Binding ShowCopyIcon,
+                                                         Source={x:Static config:UserSettings.Setting},
+                                                         Converter={StaticResource BoolToVisInverter}}" />
+                <DataGridTemplateColumn Width="Auto"
+                                        Header="{DynamicResource ColumnHead_Value}"
+                                        Visibility="{Binding ShowCopyIcon,
+                                                             Source={x:Static config:UserSettings.Setting},
+                                                             Converter={StaticResource BoolToVisConverter}}">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="{Binding Value}" />
+                                <Button Click="CopyButton_Click"
+                                        Command="{Binding DataContext.CopyCellValueCommand,
+                                                          RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                        CommandParameter="{Binding Value}"
+                                        Style="{StaticResource CopyToClipboardButton}"
+                                        Visibility="{Binding IsMouseOver,
+                                                             RelativeSource={RelativeSource AncestorType=DataGridRow},
+                                                             Converter={StaticResource BoolToVisConverter}}">
+                                    <materialDesign:PackIcon Width="16" Height="16"
+                                                             Kind="ContentCopy" />
+                                </Button>
+                            </StackPanel>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
             </DataGrid.Columns>
         </DataGrid>
     </Grid>

--- a/GetMyIP/Views/ExtrernalInfoPage.xaml.cs
+++ b/GetMyIP/Views/ExtrernalInfoPage.xaml.cs
@@ -11,4 +11,26 @@ public partial class ExternalInfoPage : UserControl
     {
         InitializeComponent();
     }
+
+    /// <summary>
+    /// Partially handles the Click event of the Button control. Returns the selected row in the parent DataGrid to the
+    /// unselected state. There is also a relay command that handles the copy to clipboard functionality. This is a
+    /// workaround necessitated by having a button in a DataGrid row. There may be a better way to do this, but this
+    /// works for now.
+    /// </summary>
+    /// <param name="sender">The source of the event.</param>
+    /// <param name="e">The event data.</param>
+    private void CopyButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not Button button)
+        {
+            return;
+        }
+        DataGridRow? row = MainWindowHelpers.FindParent<DataGridRow>(button);
+        if (row is null)
+        {
+            return;
+        }
+        row.IsSelected = false;
+    }
 }

--- a/GetMyIP/Views/InternalInfoPage.xaml
+++ b/GetMyIP/Views/InternalInfoPage.xaml
@@ -17,6 +17,8 @@
     <!--#region Resources-->
     <UserControl.Resources>
         <convert:SpacingConverter x:Key="Spacing" />
+        <convert:BoolToVisibilityInverter x:Key="BoolToVisInverter" />
+        <BooleanToVisibilityConverter x:Key="BoolToVisConverter" />
     </UserControl.Resources>
     <!--#endregion-->
 
@@ -41,7 +43,34 @@
                 <DataGridTextColumn Binding="{Binding Parameter}"
                                     Header="{DynamicResource ColumnHead_Parameter}" />
                 <DataGridTextColumn Binding="{Binding Value}"
-                                    Header="{DynamicResource ColumnHead_Value}" />
+                                    Header="{DynamicResource ColumnHead_Value}"
+                                    Visibility="{Binding ShowCopyIcon,
+                                                         Source={x:Static config:UserSettings.Setting},
+                                                         Converter={StaticResource BoolToVisInverter}}" />
+                <DataGridTemplateColumn Width="Auto"
+                                        Header="{DynamicResource ColumnHead_Value}"
+                                        Visibility="{Binding ShowCopyIcon,
+                                                             Source={x:Static config:UserSettings.Setting},
+                                                             Converter={StaticResource BoolToVisConverter}}">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock Text="{Binding Value}" />
+                                <Button Click="CopyButton_Click"
+                                        Command="{Binding DataContext.CopyCellValueCommand,
+                                                          RelativeSource={RelativeSource AncestorType={x:Type Window}}}"
+                                        CommandParameter="{Binding Value}"
+                                        Style="{StaticResource CopyToClipboardButton}"
+                                        Visibility="{Binding IsMouseOver,
+                                                             RelativeSource={RelativeSource AncestorType=DataGridRow},
+                                                             Converter={StaticResource BoolToVisConverter}}">
+                                    <materialDesign:PackIcon Width="16" Height="16"
+                                                             Kind="ContentCopy" />
+                                </Button>
+                            </StackPanel>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
             </DataGrid.Columns>
         </DataGrid>
     </Grid>

--- a/GetMyIP/Views/InternalInfoPage.xaml.cs
+++ b/GetMyIP/Views/InternalInfoPage.xaml.cs
@@ -11,4 +11,26 @@ public partial class InternalInfoPage : UserControl
     {
         InitializeComponent();
     }
+
+    /// <summary>
+    /// Partially handles the Click event of the Button control. Returns the selected row in the parent DataGrid to the
+    /// unselected state. There is also a relay command that handles the copy to clipboard functionality. This is a
+    /// workaround necessitated by having a button in a DataGrid row. There may be a better way to do this, but this
+    /// works for now.
+    /// </summary>
+    /// <param name="sender">The source of the event.</param>
+    /// <param name="e">The event data.</param>
+    private void CopyButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is not Button button)
+        {
+            return;
+        }
+        DataGridRow? row = MainWindowHelpers.FindParent<DataGridRow>(button);
+        if (row is null)
+        {
+            return;
+        }
+        row.IsSelected = false;
+    }
 }

--- a/GetMyIP/Views/SettingsPage.xaml
+++ b/GetMyIP/Views/SettingsPage.xaml
@@ -473,6 +473,7 @@
                             <RowDefinition Height="31" />
                             <RowDefinition Height="31" />
                             <RowDefinition Height="31" />
+                            <RowDefinition Height="31" />
                         </Grid.RowDefinitions>
                         <!--#endregion-->
 
@@ -513,6 +514,11 @@
                             </TextBlock>
                         </CheckBox>
                         <CheckBox Grid.Row="7"
+                                  Padding="10,0"
+                                  Content="{DynamicResource SettingsItem_ShowCopyIcon}"
+                                  IsChecked="{Binding ShowCopyIcon,
+                                                      Source={x:Static config:UserSettings.Setting}}" />
+                        <CheckBox Grid.Row="8"
                                   Padding="10,0"
                                   IsChecked="{Binding ShowExitInNav,
                                                       Source={x:Static config:UserSettings.Setting}}">


### PR DESCRIPTION
Add copy-to-clipboard icon for DataGrid cell values. This replaces current right-click behavior.

- Introduced ShowCopyIcon user setting to control display of copy-to-clipboard icon in DataGrid rows on external and internal info pages.
- Added BoolToVisibilityInverter converter to toggle icon visibility based on the setting.
- Updated ExternalInfoPage and InternalInfoPage to show a copy icon button on row hover, allowing users to copy cell values to the clipboard.
- Created CopyToClipboardButton style in ButtonStyles.xaml for the new icon button.
- Added SettingsItem_ShowCopyIcon string resource and updated localization change log in Strings.en-US.xaml.
- Added a checkbox in SettingsPage.xaml to let users toggle the ShowCopyIcon setting.
- Removed right-click-to-copy logic and command from NavigationViewModel and MainWindow.xaml, replacing it with the explicit copy button.
- Added CopyCellValue command in NavigationViewModel to handle copying and snackbar notification.
- Implemented code-behind handlers in ExternalInfoPage and InternalInfoPage to deselect the DataGrid row after copying for better UI behavior.