### PR TITLE
Remove nullable Setting refs; enforce non-null access

### DIFF
--- a/GetMyIP/App.xaml.cs
+++ b/GetMyIP/App.xaml.cs
@@ -138,7 +138,7 @@ public partial class App : Application
         }
 
         // If a language is defined in settings, and it exists in the list of defined languages, set the current culture and language to it.
-        if (!string.IsNullOrEmpty(UserSettings.Setting!.UILanguage) &&
+        if (!string.IsNullOrEmpty(UserSettings.Setting.UILanguage) &&
             UILanguage.DefinedLanguages.Exists(x => x.LanguageCode == UserSettings.Setting.UILanguage))
         {
             try
@@ -171,7 +171,7 @@ public partial class App : Application
     private void CheckLanguageTesting()
     {
         // Language testing
-        if (UserSettings.Setting!.LanguageTesting)
+        if (UserSettings.Setting.LanguageTesting)
         {
             _log.Info("Language testing enabled");
             ResourceDictionary testDict = [];

--- a/GetMyIP/Configuration/ConfigHelpers.cs
+++ b/GetMyIP/Configuration/ConfigHelpers.cs
@@ -49,7 +49,7 @@ public static class ConfigHelpers
     /// </summary>
     private static void InitializeRefreshTime()
     {
-        TimeSpan timeSpan = TimeSpan.FromSeconds(UserSettings.Setting!.AutoRefreshSeconds);
+        TimeSpan timeSpan = TimeSpan.FromSeconds(UserSettings.Setting.AutoRefreshSeconds);
         UserSettings.Setting.RefreshHours = timeSpan.Hours;
         UserSettings.Setting.RefreshMinutes = timeSpan.Minutes;
         UserSettings.Setting.RefreshSeconds = timeSpan.Seconds;
@@ -83,12 +83,12 @@ public static class ConfigHelpers
 
     #region Migrate legacy refresh interval
     /// <summary>
-    /// Converts a settings file created before the AutoRefreshInterval enum was replaced
-    /// with separate Hours/Minutes/Seconds properties. The old value was persisted as the
-    /// total number of minutes (the underlying int value of the RefreshIntervals enum).
+    /// Converts a settings file created before the AutoRefreshInterval enum was replaced with separate
+    /// Hours/Minutes/Seconds properties. The old value was persisted as the total number of minutes (the underlying int
+    /// value of the RefreshIntervals enum).
     /// </summary>
-    /// <param name="json">The raw JSON text read from the settings file.</param>
     /// <param name="settings">The already-deserialized settings instance to update in place.</param>
+    /// <param name="json">The raw JSON text read from the settings file.</param>
     private static void MigrateLegacyRefreshInterval(UserSettings settings, string json)
     {
         try
@@ -104,7 +104,7 @@ public static class ConfigHelpers
                 }
                 else
                 {
-                    string msg = "Could not migrate legacy AutoRefreshInterval setting. Using defaults.";
+                    const string msg = "Could not migrate legacy AutoRefreshInterval setting. Using defaults.";
                     _log.Warn(msg);
                     WriteBootstrapFallback(msg);
                 }

--- a/GetMyIP/Configuration/ConfigManager.cs
+++ b/GetMyIP/Configuration/ConfigManager.cs
@@ -8,5 +8,39 @@ namespace GetMyIP.Configuration;
 /// <typeparam name="T">Class name of user settings</typeparam>
 public abstract class ConfigManager<T> where T : ConfigManager<T>, new()
 {
-    public static T? Setting { get; set; }
+    /// <summary>
+    /// Detect if the application is running in design mode (e.g., in Visual Studio designer)
+    /// </summary>
+    private static readonly bool _isDesignMode =
+    DesignerProperties.GetIsInDesignMode(new DependencyObject());
+
+    /// <summary>
+    /// Gets or sets the singleton instance of the configuration manager.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"></exception>
+    /// <exception cref="InvalidOperationException"></exception>
+    public static T Setting
+    {
+        get
+        {
+            if (field is not null)
+            {
+                return field;
+            }
+
+            // If in design mode, create a new instance of T to avoid issues in the XAML designer.
+            if (_isDesignMode)
+            {
+                field = new T();
+                return field;
+            }
+
+            throw new InvalidOperationException($"ConfigManager: {typeof(T).Name}.Setting is not initialized.");
+        }
+
+        set
+        {
+            field = value ?? throw new ArgumentNullException(nameof(value));
+        }
+    }
 }

--- a/GetMyIP/Configuration/SettingChange.cs
+++ b/GetMyIP/Configuration/SettingChange.cs
@@ -29,7 +29,7 @@ public static class SettingChange
             case nameof(UserSettings.Setting.LogFile):
                 using (FileTarget? nLogTarget = LogManager.Configuration!.FindTargetByName("logPerm") as FileTarget)
                 {
-                    nLogTarget!.FileName = UserSettings.Setting!.LogFile;
+                    nLogTarget!.FileName = UserSettings.Setting.LogFile;
                 }
                 LogManager.ReconfigExistingLoggers();
                 break;
@@ -47,7 +47,7 @@ public static class SettingChange
                 break;
 
             case nameof(UserSettings.Setting.UISize):
-                MainWindowHelpers.UIScale(UserSettings.Setting!.UISize);
+                MainWindowHelpers.UIScale(UserSettings.Setting.UISize);
                 break;
 
             case nameof(UserSettings.Setting.UILanguage):

--- a/GetMyIP/Helpers/IpHelpers.cs
+++ b/GetMyIP/Helpers/IpHelpers.cs
@@ -80,7 +80,7 @@ internal static class IpHelpers
 
         string ipv4Label = GetStringResource("Internal_IPv4Address");
         string ipv6Label = GetStringResource("Internal_IPv6Address");
-        bool obfuscate = UserSettings.Setting!.ObfuscateLog;
+        bool obfuscate = UserSettings.Setting.ObfuscateLog;
         bool includeV6 = UserSettings.Setting.IncludeV6;
         IPInfo.InternalList.Clear();
 
@@ -128,7 +128,7 @@ internal static class IpHelpers
         string url;
         bool canMap;
 
-        switch (UserSettings.Setting!.InfoProvider)
+        switch (UserSettings.Setting.InfoProvider)
         {
             case PublicInfoProvider.SeeIP:
                 url = AppConstString.SeeIpURL;
@@ -269,7 +269,7 @@ internal static class IpHelpers
     /// <returns>A tuple containing the maximum retry count and retry delay in seconds.</returns>
     private static (int MaxRetries, int DelaySeconds) GetRetrySettings()
     {
-        int maxRetries = Math.Clamp(UserSettings.Setting!.RetryMax, 1, 100);
+        int maxRetries = Math.Clamp(UserSettings.Setting.RetryMax, 1, 100);
         int delaySeconds = Math.Clamp(UserSettings.Setting.RetrySeconds, 10, 3600);
         return (maxRetries, delaySeconds);
     }
@@ -308,7 +308,7 @@ internal static class IpHelpers
             return (false, ipv6RetryCount, string.Empty);
         }
 
-        if (UserSettings.Setting!.RetryIfIpv6)
+        if (UserSettings.Setting.RetryIfIpv6)
         {
             string ipAddress = ExtractIpFromJson(LatestRawExternalJson);
 
@@ -483,7 +483,7 @@ internal static class IpHelpers
         TrayIconHelpers.ShowProblemIcon = true;
         TrayIconHelpers.SetTrayIcon();
 
-        int ipv6MaxRetries = Math.Clamp(UserSettings.Setting!.RetryIfIpv6Max, 1, 100);
+        int ipv6MaxRetries = Math.Clamp(UserSettings.Setting.RetryIfIpv6Max, 1, 100);
         int ipv6Delay = Math.Clamp(UserSettings.Setting.RetryIfIpv6Seconds, 2, 60);
 
         if (ipv6RetryCount >= ipv6MaxRetries)
@@ -613,7 +613,7 @@ internal static class IpHelpers
         if (!string.IsNullOrEmpty(returnedJson))
         {
             ClearGeoInfoList();
-            switch (UserSettings.Setting!.InfoProvider)
+            switch (UserSettings.Setting.InfoProvider)
             {
                 case PublicInfoProvider.IpApiCom:
                     ProcessJson<IpApiCom>(returnedJson, quiet, "SettingsEnum_Provider_IpApiCom");
@@ -808,7 +808,7 @@ internal static class IpHelpers
                     PropertyNameCaseInsensitive = true
                 };
 
-                switch (UserSettings.Setting!.InfoProvider)
+                switch (UserSettings.Setting.InfoProvider)
                 {
                     case PublicInfoProvider.IpApiCom:
                         LogIpApiComInfo(JsonSerializer.Deserialize<IpApiCom>(json, opts));
@@ -1014,7 +1014,7 @@ internal static class IpHelpers
                 PropertyNameCaseInsensitive = true
             };
 
-            switch (UserSettings.Setting!.InfoProvider)
+            switch (UserSettings.Setting.InfoProvider)
             {
                 case PublicInfoProvider.IpApiCom:
                     {
@@ -1077,7 +1077,7 @@ internal static class IpHelpers
     /// </summary>
     private static void ShowLastRefresh()
     {
-        if (UserSettings.Setting!.ShowLastRefresh)
+        if (UserSettings.Setting.ShowLastRefresh)
         {
             Application.Current.Dispatcher.Invoke(static () =>
             {
@@ -1119,7 +1119,7 @@ internal static class IpHelpers
             return;
         }
 
-        string providerName = UserSettings.Setting!.InfoProvider.ToString();
+        string providerName = UserSettings.Setting.InfoProvider.ToString();
 
         // Configure and show the SaveFileDialog
         SaveFileDialog saveFileDialog = new()

--- a/GetMyIP/Helpers/LocalizationHelpers.cs
+++ b/GetMyIP/Helpers/LocalizationHelpers.cs
@@ -59,7 +59,7 @@ internal static class LocalizationHelpers
     /// <returns>True if the language is defined and the language exists. Otherwise return false.</returns>
     public static bool CheckUseOsLanguage(string language)
     {
-        if (UserSettings.Setting!.UseOSLanguage)
+        if (UserSettings.Setting.UseOSLanguage)
         {
             if (UILanguage.DefinedLanguages.Exists(x => x.LanguageCode == language))
             {

--- a/GetMyIP/Helpers/MainWindowHelpers.cs
+++ b/GetMyIP/Helpers/MainWindowHelpers.cs
@@ -32,7 +32,7 @@ internal static class MainWindowHelpers
 
             IpHelpers.ProcessProvider(returnedJson, false);
 
-            EnableTrayIcon(UserSettings.Setting!.MinimizeToTray);
+            EnableTrayIcon(UserSettings.Setting.MinimizeToTray);
         }
         else
         {
@@ -53,7 +53,7 @@ internal static class MainWindowHelpers
     {
         // Ensure that the initial delay is between 0 and 600 seconds.
         // This will prevent the user from entering a negative number or a number greater than 10 minutes.
-        UserSettings.Setting!.InitialDelaySecs = Math.Min(Math.Max(UserSettings.Setting.InitialDelaySecs, 0), 600);
+        UserSettings.Setting.InitialDelaySecs = Math.Min(Math.Max(UserSettings.Setting.InitialDelaySecs, 0), 600);
 
         if (UserSettings.Setting.InitialDelaySecs > 0)
         {
@@ -104,7 +104,7 @@ internal static class MainWindowHelpers
         {
             return;
         }
-        _mainWindow.Height = UserSettings.Setting!.WindowHeight;
+        _mainWindow.Height = UserSettings.Setting.WindowHeight;
         _mainWindow.Left = UserSettings.Setting.WindowLeft;
         _mainWindow.Top = UserSettings.Setting.WindowTop;
         _mainWindow.Width = UserSettings.Setting.WindowWidth;
@@ -125,7 +125,7 @@ internal static class MainWindowHelpers
     private static void SaveWindowPosition()
     {
         Window? mainWindow = Application.Current.MainWindow;
-        UserSettings.Setting!.WindowHeight = Math.Floor(mainWindow!.Height);
+        UserSettings.Setting.WindowHeight = Math.Floor(mainWindow.Height);
         UserSettings.Setting.WindowLeft = Math.Floor(mainWindow.Left);
         UserSettings.Setting.WindowTop = Math.Floor(mainWindow.Top);
         UserSettings.Setting.WindowWidth = Math.Floor(mainWindow.Width);
@@ -182,7 +182,7 @@ internal static class MainWindowHelpers
             {
                 case WindowState.Minimized:
                     {
-                        if (UserSettings.Setting!.MinimizeToTray)
+                        if (UserSettings.Setting.MinimizeToTray)
                         {
                             _mainWindow.Hide();
                         }
@@ -195,7 +195,7 @@ internal static class MainWindowHelpers
                     {
                         if (PreviousState == WindowState.Minimized)
                         {
-                            if (UserSettings.Setting!.RefreshAfterRestore)
+                            if (UserSettings.Setting.RefreshAfterRestore)
                             {
                                 _log.Debug("Main window restored from minimized. Initiating a refresh.");
                                 await NavigationViewModel.RefreshExternalAsync();
@@ -207,7 +207,7 @@ internal static class MainWindowHelpers
                             }
                         }
 
-                        if (UserSettings.Setting!.StartCentered && UserSettings.Setting.RestoreToCenter)
+                        if (UserSettings.Setting.StartCentered && UserSettings.Setting.RestoreToCenter)
                         {
                             ScreenHelpers.CenterTheWindow(_mainWindow);
                             PreviousState = _mainWindow.WindowState;
@@ -240,7 +240,7 @@ internal static class MainWindowHelpers
     #region Loaded
     private static void MainWindow_Loaded(object sender, RoutedEventArgs e)
     {
-        if (UserSettings.Setting!.AutoRefresh)
+        if (UserSettings.Setting.AutoRefresh)
         {
             RefreshHelpers.StartTimer();
         }
@@ -343,8 +343,8 @@ internal static class MainWindowHelpers
         if (mode == ThemeType.System)
         {
             mode = GetSystemTheme().Equals("light", StringComparison.OrdinalIgnoreCase)
-                ? UserSettings.Setting!.SystemLightTheme
-                : UserSettings.Setting!.SystemDarkTheme;
+                ? UserSettings.Setting.SystemLightTheme
+                : UserSettings.Setting.SystemDarkTheme;
         }
 
         switch (mode)
@@ -473,7 +473,7 @@ internal static class MainWindowHelpers
     /// </summary>
     public static void EverythingSmaller()
     {
-        MySize size = UserSettings.Setting!.UISize;
+        MySize size = UserSettings.Setting.UISize;
         if (size > 0)
         {
             size--;
@@ -487,7 +487,7 @@ internal static class MainWindowHelpers
     /// </summary>
     public static void EverythingLarger()
     {
-        MySize size = UserSettings.Setting!.UISize;
+        MySize size = UserSettings.Setting.UISize;
         if (size < MySize.Largest)
         {
             size++;
@@ -526,7 +526,7 @@ internal static class MainWindowHelpers
     /// </summary>
     public static void ShowMainWindow()
     {
-        Application.Current.MainWindow!.Show();
+        Application.Current.MainWindow.Show();
         Application.Current.MainWindow.Visibility = Visibility.Visible;
         Application.Current.MainWindow.WindowState = WindowState.Normal;
         Application.Current.MainWindow.ShowInTaskbar = true;

--- a/GetMyIP/Helpers/NLogHelpers.cs
+++ b/GetMyIP/Helpers/NLogHelpers.cs
@@ -17,7 +17,7 @@ internal static class NLogHelpers
 
     internal static string GetPermanentLogFilePath()
     {
-        return string.IsNullOrEmpty(UserSettings.Setting!.LogFile)
+        return string.IsNullOrEmpty(UserSettings.Setting.LogFile)
             ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Desktop), "GetMyIP.log")
             : UserSettings.Setting.LogFile;
     }
@@ -104,7 +104,7 @@ internal static class NLogHelpers
         #endregion Debugger
 
         // Lastly, set the logging level based on setting
-        SetLogLevel(UserSettings.Setting!.IncludeDebug);
+        SetLogLevel(UserSettings.Setting.IncludeDebug);
     }
 
     /// <summary>

--- a/GetMyIP/Helpers/RefreshHelpers.cs
+++ b/GetMyIP/Helpers/RefreshHelpers.cs
@@ -24,7 +24,7 @@ internal static class RefreshHelpers
     /// </summary>
     public static void StartTimer()
     {
-        int intervalSeconds = UserSettings.Setting!.AutoRefreshSeconds;
+        int intervalSeconds = UserSettings.Setting.AutoRefreshSeconds;
         intervalSeconds = VerifyRefreshInterval(intervalSeconds);
         TimeSpan interval = TimeSpan.FromSeconds(intervalSeconds);
         _refreshTimer ??= new System.Timers.Timer()
@@ -146,7 +146,7 @@ internal static class RefreshHelpers
     /// </summary>
     public static void HandleRefreshIntervalChanged()
     {
-        int refreshSeconds = (UserSettings.Setting!.RefreshHours * 3600) + (UserSettings.Setting.RefreshMinutes * 60) + UserSettings.Setting.RefreshSeconds;
+        int refreshSeconds = (UserSettings.Setting.RefreshHours * 3600) + (UserSettings.Setting.RefreshMinutes * 60) + UserSettings.Setting.RefreshSeconds;
         int autoRefreshSeconds = VerifyRefreshInterval(refreshSeconds);
         UserSettings.Setting.AutoRefreshSeconds = autoRefreshSeconds;
         SettingsViewModel.UpdateRefresh();
@@ -165,7 +165,7 @@ internal static class RefreshHelpers
         {
             _log.Warn($"Invalid refresh interval ({intervalSeconds} seconds). Must be between {MinRefreshSeconds} sec and {MaxRefreshSeconds} sec. Reverting to one hour.");
             var defaultTime = TimeSpan.FromSeconds(DefaultRefreshSeconds);
-            UserSettings.Setting!.RefreshHours = defaultTime.Hours;
+            UserSettings.Setting.RefreshHours = defaultTime.Hours;
             UserSettings.Setting.RefreshMinutes = defaultTime.Minutes;
             UserSettings.Setting.RefreshSeconds = defaultTime.Seconds;
             intervalSeconds = DefaultRefreshSeconds;

--- a/GetMyIP/Helpers/ScreenHelpers.cs
+++ b/GetMyIP/Helpers/ScreenHelpers.cs
@@ -19,7 +19,7 @@ internal static class ScreenHelpers
             return;
         }
 
-        PresentationSource source = PresentationSource.FromVisual(window)!;
+        PresentationSource source = PresentationSource.FromVisual(window);
         double dpiScale = source.CompositionTarget?.TransformFromDevice.M11 ?? 1.0;
 
         IntPtr hwnd = new WindowInteropHelper(window).Handle;
@@ -37,7 +37,7 @@ internal static class ScreenHelpers
     /// </summary>
     public static void KeepWindowOnScreen(Window? window)
     {
-        if (window is null || (UserSettings.Setting!.RestoreToCenter && UserSettings.Setting.StartCentered))
+        if (window is null || (UserSettings.Setting.RestoreToCenter && UserSettings.Setting.StartCentered))
         {
             return;
         }

--- a/GetMyIP/Helpers/ToolTipHelper.cs
+++ b/GetMyIP/Helpers/ToolTipHelper.cs
@@ -13,7 +13,7 @@ internal static class ToolTipHelper
         StringBuilder sb = new();
         bool isValid = true;
 
-        if (UserSettings.Setting!.ShowHeader && !string.IsNullOrEmpty(UserSettings.Setting.TooltipHeading))
+        if (UserSettings.Setting.ShowHeader && !string.IsNullOrEmpty(UserSettings.Setting.TooltipHeading))
         {
             string version = Assembly.GetExecutingAssembly().GetName().Version?.ToString(3)!;
             if (UserSettings.Setting.TooltipHeading.Contains("%ver-nl%"))

--- a/GetMyIP/Helpers/TrayIconHelpers.cs
+++ b/GetMyIP/Helpers/TrayIconHelpers.cs
@@ -29,7 +29,7 @@ internal static class TrayIconHelpers
         }
 
         string? countryCode = GetCountryCode();
-        if (UserSettings.Setting!.ShowFlagIcon)
+        if (UserSettings.Setting.ShowFlagIcon)
         {
             if (countryCode == CurrentCountryCode)
             {

--- a/GetMyIP/ViewModels/AboutViewModel.cs
+++ b/GetMyIP/ViewModels/AboutViewModel.cs
@@ -21,11 +21,11 @@ public partial class AboutViewModel
     /// </summary>
     private static async Task<bool> CheckForNewReleaseOnLoadAsync()
     {
-        if (!UserSettings.Setting!.AutoCheckForUpdates)
+        if (!UserSettings.Setting.AutoCheckForUpdates)
         {
             return true;
         }
-        if (TempSettings.Setting!.CheckedForNewRelease)
+        if (TempSettings.Setting.CheckedForNewRelease)
         {
             return true;
         }

--- a/GetMyIP/ViewModels/NavigationViewModel.cs
+++ b/GetMyIP/ViewModels/NavigationViewModel.cs
@@ -11,7 +11,7 @@ internal sealed partial class NavigationViewModel : ObservableObject
 
         if (CurrentViewModel is null)
         {
-            Navigate(FindNavPage(UserSettings.Setting!.InitialPage));
+            Navigate(FindNavPage(UserSettings.Setting.InitialPage));
         }
     }
     #endregion Constructor
@@ -106,7 +106,7 @@ internal sealed partial class NavigationViewModel : ObservableObject
                 CurrentViewModel = null;
                 CurrentViewModel = Activator.CreateInstance((Type)item.ViewModelType);
                 NavItem = item;
-                TempSettings.Setting!.CurrentPage = item.NavPage.ToString();
+                TempSettings.Setting.CurrentPage = item.NavPage.ToString();
             }
         }
     }
@@ -369,7 +369,7 @@ internal sealed partial class NavigationViewModel : ObservableObject
     private static void StopRefresh()
     {
         RefreshHelpers.StopTimer();
-        UserSettings.Setting!.AutoRefresh = false;
+        UserSettings.Setting.AutoRefresh = false;
     }
     #endregion Stop refresh timers
 
@@ -492,7 +492,7 @@ internal sealed partial class NavigationViewModel : ObservableObject
 
     private static void DecreaseFontSize()
     {
-        if (UserSettings.Setting!.SelectedFontSize > 8)
+        if (UserSettings.Setting.SelectedFontSize > 8)
         {
             UserSettings.Setting.SelectedFontSize--;
         }
@@ -501,7 +501,7 @@ internal sealed partial class NavigationViewModel : ObservableObject
 
     private static void IncreaseFontSize()
     {
-        if (UserSettings.Setting!.SelectedFontSize < 24)
+        if (UserSettings.Setting.SelectedFontSize < 24)
         {
             UserSettings.Setting.SelectedFontSize++;
         }
@@ -510,7 +510,7 @@ internal sealed partial class NavigationViewModel : ObservableObject
 
     private static void CycleProviders()
     {
-        if (UserSettings.Setting!.InfoProvider >= PublicInfoProvider.IP2Location)
+        if (UserSettings.Setting.InfoProvider >= PublicInfoProvider.IP2Location)
         {
             UserSettings.Setting.InfoProvider = PublicInfoProvider.IpApiCom;
         }
@@ -535,7 +535,7 @@ internal sealed partial class NavigationViewModel : ObservableObject
 
     private static void CycleColor()
     {
-        if (UserSettings.Setting!.PrimaryColor >= AccentColor.White)
+        if (UserSettings.Setting.PrimaryColor >= AccentColor.White)
         {
             UserSettings.Setting.PrimaryColor = AccentColor.Red;
         }
@@ -548,7 +548,7 @@ internal sealed partial class NavigationViewModel : ObservableObject
 
     private static void CycleTheme()
     {
-        UserSettings.Setting!.UITheme = UserSettings.Setting.UITheme switch
+        UserSettings.Setting.UITheme = UserSettings.Setting.UITheme switch
         {
             ThemeType.Light => ThemeType.LightGray,
             ThemeType.LightGray => ThemeType.Dark,
@@ -573,19 +573,19 @@ internal sealed partial class NavigationViewModel : ObservableObject
         {
             case "size":
                 composite = MsgTextUISizeSet;
-                messageVar = EnumDescConverter.GetEnumDescription(UserSettings.Setting!.UISize);
+                messageVar = EnumDescConverter.GetEnumDescription(UserSettings.Setting.UISize);
                 break;
             case "theme":
                 composite = MsgTextUIThemeSet;
-                messageVar = EnumDescConverter.GetEnumDescription(UserSettings.Setting!.UITheme);
+                messageVar = EnumDescConverter.GetEnumDescription(UserSettings.Setting.UITheme);
                 break;
             case "color":
                 composite = MsgTextUIColorSet;
-                messageVar = EnumDescConverter.GetEnumDescription(UserSettings.Setting!.PrimaryColor);
+                messageVar = EnumDescConverter.GetEnumDescription(UserSettings.Setting.PrimaryColor);
                 break;
             case "fontSize":
                 composite = MsgTextFontSizeSet;
-                messageVar = UserSettings.Setting!.SelectedFontSize.ToString(CultureInfo.CurrentCulture);
+                messageVar = UserSettings.Setting.SelectedFontSize.ToString(CultureInfo.CurrentCulture);
                 break;
         }
 

--- a/GetMyIP/ViewModels/SettingsViewModel.cs
+++ b/GetMyIP/ViewModels/SettingsViewModel.cs
@@ -39,7 +39,7 @@ public partial class SettingsViewModel : ObservableObject
     [RelayCommand]
     private static void ViewPermLog()
     {
-        if (!string.IsNullOrEmpty(UserSettings.Setting!.LogFile) && File.Exists(UserSettings.Setting.LogFile))
+        if (!string.IsNullOrEmpty(UserSettings.Setting.LogFile) && File.Exists(UserSettings.Setting.LogFile))
         {
             TextFileViewer.ViewTextFile(UserSettings.Setting.LogFile);
         }
@@ -58,7 +58,7 @@ public partial class SettingsViewModel : ObservableObject
     [RelayCommand]
     private static async Task TestLogging()
     {
-        if (!string.IsNullOrEmpty(UserSettings.Setting!.LogFile))
+        if (!string.IsNullOrEmpty(UserSettings.Setting.LogFile))
         {
             string json = await IpHelpers.GetExternalInfo();
             IpHelpers.LogIPInfo(json);
@@ -205,7 +205,7 @@ public partial class SettingsViewModel : ObservableObject
     [RelayCommand]
     public static void UpdateRefresh()
     {
-        if (UserSettings.Setting!.AutoRefresh)
+        if (UserSettings.Setting.AutoRefresh)
         {
             RefreshHelpers.StopTimer();
             Task.Delay(50).Wait();
@@ -213,7 +213,7 @@ public partial class SettingsViewModel : ObservableObject
             SnackBarMsg.QueueMessageNoClear(GetStringResource("MsgText_Refreshed"), 1500);
         }
         else
-        { 
+        {
             RefreshHelpers.StopTimer();
         }
     }


### PR DESCRIPTION
Remove nullable Setting refs; enforce non-null access

- Refactored codebase to eliminate all null-forgiving operators and nullable references to UserSettings.Setting and TempSettings.Setting.
- These properties are now non-nullable and throw exceptions if accessed before initialization, improving type safety and removing the need for repetitive null checks.
- Updated ConfigManager<T>.Setting to enforce non-null assignment and access.
- All usages of Setting throughout helpers, view models, and UI code-behind were updated to match the new contract.